### PR TITLE
1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,22 +6,49 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.1.0] - 2021-07-19
+
+### Added
+
+- [`77f326a`][77f326a]  
+  Abstract `TestingExpect` class to manage `expect()` function of jasmine.
+
+- [`afb98f5`][afb98f5]  
+  Class `TestingToBeMatchers` with matchers that use the `toBe()` method of `jasmine.Matchers`.
+
+- [`3bf2046`][3bf2046]  
+  Tests for the `TestingToBeMatchers`.
+
+### Changed
+
+- [`4b81d0c`][4b81d0c] [`bdfbfe2`][bdfbfe2] [`8229336`][8229336] [`c17d11e`][c17d11e] [`9e0e368`][9e0e368]  
+  Update README.md with `TestingToBeMatchers`.
+
+[77f326a]: https://github.com/angular-package/testing/commit/77f326a5bc7154b55f6944e60b24cddb5bfe93df
+[afb98f5]: https://github.com/angular-package/testing/commit/afb98f557296239b10227e8f0bde4f8b62fd5049
+[3bf2046]: https://github.com/angular-package/testing/commit/3bf2046ee35f9d0ae4769cb107be2c61e281af34
+[4b81d0c]: https://github.com/angular-package/testing/commit/4b81d0cb26e145bed02656064ac9c86a10bfa296
+[bdfbfe2]: https://github.com/angular-package/testing/commit/bdfbfe226589620cba6a912694dcfd9cfc3020ac
+[8229336]: https://github.com/angular-package/testing/commit/8229336755c6efd3151d974d53ec8860cf108280
+[c17d11e]: https://github.com/angular-package/testing/commit/c17d11e1c23db009c3bec05e84a02f75a90f7fa0
+[9e0e368]: https://github.com/angular-package/testing/commit/9e0e3689acb765fe4ffd53962d7b7607cd2761a3
+
 ## [1.0.1] - 2021-07-14
   
 ### Changed
 
-- [`10be25d`][10be25d]
+- [`10be25d`][10be25d]  
   Change peerDependencies.
 
-- [`58bdbad`][58bdbad]
+- [`58bdbad`][58bdbad]  
   946803f Change the parameter `value` description.
 
 ### Fixed
 
-- [`58bdbad`][58bdbad]
+- [`58bdbad`][58bdbad]  
   Fix `toBe()` and `toEqual()` method by adding a generic `Value` instead of any.
 
-- [`946803f`][946803f]
+- [`946803f`][946803f]  
   Fix `instanceof` link in the README.md.
 
 [10be25d]: https://github.com/angular-package/testing/commit/10be25daffacf87f38b469b999cbb2b213fb90a1

--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ Support for testing other packages.
 * [Skeleton](#skeleton)
 * [Installation](#installation)
 * [Instance of](#instance-of)
-* [Testing](#testing)
+* Testing
+  * [`Testing`](#testing)
+  * [`TestingToBeMatchers`](#testingtobematchers)
 * [Constants](#constants)
 * [Git](#git)
   * [Commit](#commit)
@@ -1846,6 +1848,1300 @@ const testing = new Testing(true, true);
  */
 const firstName = 'My name';
 testing.describe(`toEqual`, () => testing.toEqual('Expects `firstName` to equal to `My name`', firstName, 'My name'));
+```
+
+<br>
+
+### `TestingToBeMatchers`
+
+Matchers that use the `toBe()` method of `jasmine.Matchers`.
+
+**Instance methods:**
+
+| TestingToBeMatchers.prototype.                                    | Description |
+| :---------------------------------------------------------------- | :---------- |
+| [`array()`](#testingtobematchersprototypearray)                   | Expects provided `value` to be an [`array`][js-array] |
+| [`bigint()`](#testingtobematchersprototypebigint)                 | Expects provided `value` to be a [`bigint`][js-bigint] |
+| [`boolean()`](#testingtobematchersprototypeboolean)               | Expects provided `value` to be a [`boolean`][js-boolean] type |
+| [`class()`](#testingtobematchersprototypeclass)                   | Expects provided `value` to be a [`class`][js-classes] |
+| [`date()`](#testingtobematchersprototypedate)                     | Expects provided `value` to be a [`Date`][js-date] |
+| [`defined()`](#testingtobematchersprototypdefined)                | Expects provided `value` to be defined |
+| [`false()`](#testingtobematchersprototypefalse)                   | Expects provided `value` to be [`false`][js-boolean] |
+| [`function()`](#testingtobematchersprototypefunction)             | Expects provided `value` to be [`function`][js-function] |
+| [`instance()`](#testingtobematchersprototypeinstance)             | Expects provided `value` to be an instance of the given class from the `constructor` |
+| [`key()`](#testingtobematchersprototypekey)                       | Expects provided `value` to be a property key |
+| [`null()`](#testingtobematchersprototypenull)                     | Expects provided `value` to be [`null`][js-null] |
+| [`number()`](#testingtobematchersprototypenumber)                 | Expects provided `value` to be a `number` |
+| [`numberBetween()`](#testingtobematchersprototypenumberbetween)   | Expects provided `value` to be a `number` between minimum and maximum |
+| [`object()`](#testingtobematchersprototypeobject)                 | Expects provided `value` to be an `object` |
+| [`objectKey()`](#testingtobematchersprototypeobjectkey)           | Expects provided `value` to be an `object` with the given key or keys by using the [`hasOwnProperty`][js-hasownproperty] method of [`Object`][js-object] |
+| [`objectKeyIn()`](#testingtobematchersprototypeobjectkeyin)       | Expects provided `value` to be an `object` with the given key or keys by using the [`in`][js-in-operator] operator |
+| [`objectKeys()`](#testingtobematchersprototypeobjectkeys)         | Expects provided `value` to be an `object` with some of the given keys by using the [`hasOwnProperty`][js-hasownproperty] method of [`Object`][js-object] |
+| [`regexp()`](#testingtobematchersprototyperegexp)                 | Expects provided `value` to be [`RegExp`][js-regexp] |
+| [`string()`](#testingtobematchersprototypestring)                 | Expects provided `value` to be a [`string`][js-string] |
+| [`stringOfLength()`](#testingtobematchersprototypestringoflength) | Expects provided `value` to be a [`string`][js-string] of the specified minimum and maximum length |
+| [`symbol()`](#testingtobematchersprototypesymbol)                 | Expects provided `value` to be a [`symbol`][js-symbol] |
+| [`true()`](#testingtobematchersprototypetrue)                     | Expects provided `value` to be `true` |
+| [`undefined()`](#testingtobematchersprototypeundefined)           | Expects provided `value` to be [`undefined`][js-undefined] |
+
+<br>
+
+### `TestingToBeMatchers.prototype.array()`
+
+Expects provided `value` to be an [`array`][js-array]. The method uses [`isArray()`](https://github.com/angular-package/type#isarray) function from the [`@angular-package/type`][type-github-readme].
+
+```typescript
+public array(
+  value: any,
+  expected: jasmine.Expected<boolean> = true,
+  expectationFailOutput: any = `${this.expectationFailOutput} ${
+    this.getNot() === true ? `not` : ``
+  } be an \`array\``
+): this {
+  this.toBe(is.array(value), expected, expectationFailOutput);
+  return this;
+}
+```
+
+**Parameters:**
+
+| Name: type                   | Description |
+| :--------------------------- | :---------- |
+| `value: any`                 | The `value` of any type that is checked against the [`array`][js-array] and the result of its check is passed to the [`expect()`][jasmine-expect] function of jasmine |
+| `expected: boolean`          | The expected value of a [`boolean`][js-boolean] to compare against the result of the `value` check that is passed to the `toBe()` method of `jasmine.Matchers` |
+| `expectationFailOutput: any` | An additional message when the matcher fails, by default, states the value should be (or not) an [`array`][js-array] |
+
+**Returns:**
+
+The **return value** is an instance of a [`TestingToBeMatchers`](#testingtobematchers).
+
+**Usage:**
+
+```typescript
+// Example usage.
+import { Testing, TestingToBeMatchers } from '@angular-package/testing';
+/**
+ * Create `Testing` instance.
+ */
+const testing = new Testing(true, true);
+const toBe = new TestingToBeMatchers();
+/**
+ * Tests.
+ */
+testing.describe('Expects provided value', () => {
+  let testArray: any;
+  beforeEach(() => (testArray = [1, 'two', 3]));
+
+  testing.describe('to be or not', () => {
+    testing.it('an array', () => toBe.array(testArray).not.array(2));
+  });
+});
+```
+
+<br>
+
+### `TestingToBeMatchers.prototype.bigint()`
+
+Expects provided `value` to be [`bigint`][js-bigint] type. The method uses [`isBigInt()`](https://github.com/angular-package/type#isbigint) function from the [`@angular-package/type`][type-github-readme].
+
+```typescript
+public bigint(
+  value: any,
+  expected: jasmine.Expected<boolean> = true,
+  expectationFailOutput: any = `${this.expectationFailOutput} ${
+    this.getNot() === true ? `not` : ``
+  } be \`bigint\``
+): this {
+  this.toBe(is.bigint(value), expected, expectationFailOutput);
+  return this;
+}
+```
+
+**Parameters:**
+
+| Name: type                   | Description |
+| :--------------------------- | :---------- |
+| `value: Value`               | The `value` of any type that is checked against the [`bigint`][js-bigint], and the result of its check is passed to the [`expect()`][jasmine-expect] function of jasmine |
+| `expected: boolean`          | The expected value of a [`boolean`][js-boolean] to compare against the result of the `value` check that is passed to the `toBe()` method of `jasmine.Matchers` |
+| `expectationFailOutput: any` | An additional message when the matcher fails, by default, states the `value` should be (or not) [`bigint`][js-bigint]  |
+
+**Returns:**
+
+The **return value** is an instance of a [`TestingToBeMatchers`](#testingtobematchers).
+
+**Usage:**
+
+```typescript
+// Example usage.
+import { Testing, TestingToBeMatchers } from '@angular-package/testing';
+/**
+ * Create `Testing` instance.
+ */
+const testing = new Testing(true, true);
+const toBe = new TestingToBeMatchers();
+/**
+ * Tests.
+ */
+testing.describe('Expects provided value', () => {
+  let isBigint: any;
+  beforeEach(() => (isBigint = 12n));
+
+  testing.describe('to be or not', () => {
+    testing.it('bigint', () => toBe.bigint(isBigint).not.bigint(2));
+  });
+});
+```
+
+<br>
+
+### `TestingToBeMatchers.prototype.boolean()`
+
+Expects provided `value` to be [`boolean`][js-boolean]. The method uses [`isBoolean()`](https://github.com/angular-package/type#isboolean) function from the [`@angular-package/type`][type-github-readme].
+
+```typescript
+public boolean(
+  value: any,
+  expected: jasmine.Expected<boolean> = true,
+  expectationFailOutput: any = `${this.expectationFailOutput} ${
+    this.getNot() === true ? `not` : ``
+  } be \`boolean\``
+): this {
+  this.toBe(is.boolean(value), expected, expectationFailOutput);
+  return this;
+}
+```
+
+**Parameters:**
+
+| Name: type                   | Description |
+| :--------------------------- | :---------- |
+| `value: any`                 | The `value` of any type that is checked against the [`boolean`][js-boolean], and the result of its check is passed to the [`expect()`][jasmine-expect] function of jasmine |
+| `expected: boolean`          | The expected value of a [`boolean`][js-boolean] to compare against the result of the `value` check that is passed to the `toBe()` method of `jasmine.Matchers` |
+| `expectationFailOutput: any` | An additional message when the matcher fails, by default, states the `value` should be (or not) [`boolean`][js-boolean]  |
+
+**Returns:**
+
+The **return value** is an instance of a [`TestingToBeMatchers`](#testingtobematchers).
+
+**Usage:**
+
+```typescript
+// Example usage.
+import { Testing, TestingToBeMatchers } from '@angular-package/testing';
+/**
+ * Create `Testing` instance.
+ */
+const testing = new Testing(true, true);
+const toBe = new TestingToBeMatchers();
+/**
+ * Tests.
+ */
+testing.describe('Expects provided value', () => {
+  let isBoolean: any;
+  beforeEach(() => (isBoolean = false));
+
+  testing.describe('to be or not to be the type of', () => {
+    testing.it('boolean', () => toBe.boolean(isBoolean).not.boolean(3));
+  });
+});
+```
+
+<br>
+
+### `TestingToBeMatchers.prototype.class()`
+
+Expects provided `value` to be [`class`][js-classes]. The method uses [`isClass()`](https://github.com/angular-package/type#isclass) function from the [`@angular-package/type`][type-github-readme].
+
+```typescript
+public class(
+  value: any,
+  expected: jasmine.Expected<boolean> = true,
+  expectationFailOutput: any = `${this.expectationFailOutput} ${
+    this.getNot() === true ? `not` : ``
+  } be \`class\``
+): this {
+  this.toBe(is.class(value), expected, expectationFailOutput);
+  return this;
+}
+```
+
+**Parameters:**
+
+| Name: type                   | Description |
+| :--------------------------- | :---------- |
+| `value: any`                 | The `value` of any type that is checked against the [`class`][js-classes], and the result of its check is passed to the [`expect()`][jasmine-expect] function of jasmine |
+| `expected: boolean`          | The expected value of a [`boolean`][js-boolean] to compare against the result of the `value` check that is passed to the `toBe()` method of `jasmine.Matchers` |
+| `expectationFailOutput: any` | An additional message when the matcher fails, by default, states the `value` should be (or not) [`class`][js-classes]  |
+
+**Returns:**
+
+The **return value** is an instance of a [`TestingToBeMatchers`](#testingtobematchers).
+
+**Usage:**
+
+```typescript
+// Example usage.
+import { Testing, TestingToBeMatchers } from '@angular-package/testing';
+/**
+ * Create `Testing` instance.
+ */
+const testing = new Testing(true, true);
+const toBe = new TestingToBeMatchers();
+/**
+ * Tests.
+ */
+testing.describe('Expects provided value', () => {
+  let isClass: any;
+  beforeEach(() => (isClass = class TestingClass {}));
+  testing.describe('to be or not to be', () => {
+    testing.it('class', () => toBe.class(isClass).not.class('TestingClass'));
+  });
+});
+```
+
+<br>
+
+### `TestingToBeMatchers.prototype.date()`
+
+Expects provided `value` to be a [`date`][js-date]. The method uses [`isDate()`](https://github.com/angular-package/type#isdate) function from the [`@angular-package/type`][type-github-readme].
+
+```typescript
+public date(
+  value: any,
+  expected: jasmine.Expected<boolean> = true,
+  expectationFailOutput: any = `${this.expectationFailOutput} ${
+    this.getNot() === true ? `not` : ``
+  } be a \`date\``
+): this {
+  this.toBe(is.date(value), expected, expectationFailOutput);
+  return this;
+}
+```
+
+**Parameters:**
+
+| Name: type                   | Description |
+| :--------------------------- | :---------- |
+| `value: any`                 | The `value` of any type that is checked against [`date`][js-date], and the result of its check is passed to the [`expect()`][jasmine-expect] function of jasmine |
+| `expected: boolean`          | The expected value of a [`boolean`][js-boolean] to compare against the result of the `value` check that is passed to the `toBe()` method of `jasmine.Matchers` |
+| `expectationFailOutput: any` | An additional message when the matcher fails, by default, states the `value` should be (or not) a [`date`][js-date]  |
+
+**Returns:**
+
+The **return value** is an instance of a [`TestingToBeMatchers`](#testingtobematchers).
+
+**Usage:**
+
+```typescript
+// Example usage.
+import { Testing, TestingToBeMatchers } from '@angular-package/testing';
+/**
+ * Create `Testing` instance.
+ */
+const testing = new Testing(true, true);
+const toBe = new TestingToBeMatchers();
+/**
+ * Tests.
+ */
+testing.describe('Expects provided value', () => {
+  let isDate: any;
+  beforeEach(() => (isDate = new Date()));
+  testing.describe('to be or not to be the type of', () => {
+    testing.it('date', () => toBe.date(isDate).not.date(false));
+  });
+});
+```
+
+<br>
+
+### `TestingToBeMatchers.prototype.defined()`
+
+Expects provided `value` to be defined. The method uses [`isDefined()`](https://github.com/angular-package/type#isdefined) function from the [`@angular-package/type`][type-github-readme].
+
+```typescript
+public defined(
+  value: any,
+  expected: jasmine.Expected<boolean> = true,
+  expectationFailOutput: any = `${this.expectationFailOutput} ${
+    this.getNot() === true ? `not` : ``
+  } be defined`
+): this {
+  this.toBe(is.defined(value), expected, expectationFailOutput);
+  return this;
+}
+```
+
+**Parameters:**
+
+| Name: type                   | Description |
+| :--------------------------- | :---------- |
+| `value: any`                 | The `value` of any type that is checked to the defined and the result of its check is passed to the [`expect()`][jasmine-expect] function of jasmine |
+| `expected: boolean`          | The expected value of a [`boolean`][js-boolean] to compare against the result of the `value` check that is passed to the `toBe()` method of `jasmine.Matchers` |
+| `expectationFailOutput: any` | An additional message when the matcher fails, by default, states the `value` should be (or not) defined  |
+
+**Returns:**
+
+The **return value** is an instance of a [`TestingToBeMatchers`](#testingtobematchers).
+
+**Usage:**
+
+```typescript
+// Example usage.
+import { Testing, TestingToBeMatchers } from '@angular-package/testing';
+/**
+ * Create `Testing` instance.
+ */
+const testing = new Testing(true, true);
+const toBe = new TestingToBeMatchers();
+/**
+ * Tests.
+ */
+testing.describe('Expects provided value', () => {
+  let isDefined: any;
+  testing.describe('to be or not to be', () => {
+    testing.it('defined', () => toBe.defined('Defined').not.defined(isDefined));
+  });
+});
+```
+
+<br>
+
+### `TestingToBeMatchers.prototype.false()`
+
+Expects provided `value` to be `false`. The method uses [`isFalse()`](https://github.com/angular-package/type#isfalse) function from the [`@angular-package/type`][type-github-readme].
+
+```typescript
+public false(
+  value: any,
+  expected: jasmine.Expected<boolean> = true,
+  expectationFailOutput: any = `${this.expectationFailOutput} ${
+    this.getNot() === true ? `not` : ``
+  } be \`false\``
+): this {
+  this.toBe(is.false(value), expected, expectationFailOutput);
+  return this;
+}
+```
+
+**Parameters:**
+
+| Name: type                   | Description |
+| :--------------------------- | :---------- |
+| `value: any`                 | The `value` of any type that is checked against `false` and the result of its check is passed to the [`expect()`][jasmine-expect] function of jasmine |
+| `expected: boolean`          | The expected value of a [`boolean`][js-boolean] to compare against the result of the `value` check that is passed to the `toBe()` method of `jasmine.Matchers` |
+| `expectationFailOutput: any` | An additional message when the matcher fails, by default, states the `value` should be (or not) `false` |
+
+**Returns:**
+
+The **return value** is an instance of a [`TestingToBeMatchers`](#testingtobematchers).
+
+**Usage:**
+
+```typescript
+// Example usage.
+import { Testing, TestingToBeMatchers } from '@angular-package/testing';
+/**
+ * Create `Testing` instance.
+ */
+const testing = new Testing(true, true);
+const toBe = new TestingToBeMatchers();
+/**
+ * Tests.
+ */
+testing.describe('Expects provided value', () => {
+  let isFalse: any;
+  beforeEach(() => (isFalse = false));
+  testing.describe('to be or not to be', () => {
+    testing.it('`false`', () => toBe.false(isFalse).not.false(true));
+  });
+});
+```
+
+<br>
+
+### `TestingToBeMatchers.prototype.function()`
+
+Expects provided `value` to be [`function`][js-function]. The method uses [`isFunction()`](https://github.com/angular-package/type#isfunction) function from the [`@angular-package/type`][type-github-readme].
+
+```typescript
+public function(
+  value: any,
+  expected: jasmine.Expected<boolean> = true,
+  expectationFailOutput: any = `${this.expectationFailOutput} ${
+    this.getNot() === true ? `not` : ``
+  } be a function`
+): this {
+  this.toBe(is.function(value), expected, expectationFailOutput);
+  return this;
+}
+```
+
+**Parameters:**
+
+| Name: type                   | Description |
+| :--------------------------- | :---------- |
+| `value: any`                 | The `value` of any type that is checked against [`function`][js-function] and the result of its check is passed to the [`expect()`][jasmine-expect] function of jasmine |
+| `expected: boolean`          | The expected value of a [`boolean`][js-boolean] to compare against the result of the `value` check that is passed to the `toBe()` method of `jasmine.Matchers` |
+| `expectationFailOutput: any` | An additional message when the matcher fails, by default, states the `value` should be (or not) [`function`][js-function] |
+
+**Returns:**
+
+The **return value** is an instance of a [`TestingToBeMatchers`](#testingtobematchers).
+
+**Usage:**
+
+```typescript
+// Example usage.
+import { Testing, TestingToBeMatchers } from '@angular-package/testing';
+/**
+ * Create `Testing` instance.
+ */
+const testing = new Testing(true, true);
+const toBe = new TestingToBeMatchers();
+/**
+ * Tests.
+ */
+testing.describe('Expects provided value', () => {
+  let isFunction: any;
+  beforeEach(() => (isFunction = () => {}));
+  testing.describe('to be or not to be', () => {
+    testing.it('`function`', () => toBe.function(isFunction).not.function(true));
+  });
+});
+```
+
+<br>
+
+### `TestingToBeMatchers.prototype.instance()`
+
+Expects provided `value` to be [`function`][js-function]. The method uses [`isFunction()`](https://github.com/angular-package/type#isfunction) function from the [`@angular-package/type`][type-github-readme].
+
+```typescript
+public instance<Type>(
+  value: any,
+  constructor: Constructor<Type>,
+  expected: jasmine.Expected<boolean> = true,
+  expectationFailOutput: any = `${this.expectationFailOutput} ${
+    this.getNot() === true ? `not` : ``
+  } be an instance of ${constructor.name}`
+): this {
+  this.toBe(is.instance(value, constructor), expected, expectationFailOutput);
+  return this;
+}
+```
+
+**Generic type variables:**
+
+**Parameters:**
+
+| Name: type                       | Description |
+| :------------------------------- | :---------- |
+| `value: any`                     | The `value` of any type that is checked against [`function`][js-function] and the result of its check is passed to the [`expect()`][jasmine-expect] function of jasmine |
+| `constructor: Constructor<Type>` | A [`class`][js-classes] or [`function`][js-function] that specifies the type of the `constructor` |
+| `expected: boolean`              | The expected value of a [`boolean`][js-boolean] to compare against the result of the `value` check that is passed to the `toBe()` method of `jasmine.Matchers` |
+| `expectationFailOutput: any`     | An additional message when the matcher fails, by default, states the `value` should be (or not) an instance of the given [`class`][js-classes] |
+
+**Returns:**
+
+The **return value** is an instance of a [`TestingToBeMatchers`](#testingtobematchers).
+
+**Usage:**
+
+```typescript
+// Example usage.
+import { Testing, TestingToBeMatchers, TestingClass } from '@angular-package/testing';
+/**
+ * Create `Testing` instance.
+ */
+const testing = new Testing(true, true);
+const toBe = new TestingToBeMatchers();
+/**
+ * Tests.
+ */
+testing.describe('Expects provided value', () => {
+  let isInstance: any;
+  beforeEach(() => isInstance = new TestingClass());
+  testing.describe('to be or not to be', () => {
+    testing.it(`an instance of \`TestingClass\``, () => toBe.instance(isInstance, TestingClass).not.instance(isInstance, class Person {}));
+  });
+});
+```
+
+<br>
+
+### `TestingToBeMatchers.prototype.key()`
+
+Expects provided `value` to be property key. The method uses [`isKey()`](https://github.com/angular-package/type#iskey) function from the [`@angular-package/type`][type-github-readme].
+
+```typescript
+public key(
+  value: any,
+  expected: jasmine.Expected<boolean> = true,
+  expectationFailOutput: any = `${this.expectationFailOutput} ${
+    this.getNot() === true ? `not` : ``
+  } be the property key`
+): this {
+  this.toBe(is.key(value), expected, expectationFailOutput);
+  return this;
+}
+```
+
+**Parameters:**
+
+| Name: type                   | Description |
+| :--------------------------- | :---------- |
+| `value: any`                 | The `value` of any type that is checked against the property key and the result of its check is passed to the [`expect()`][jasmine-expect] function of jasmine |
+| `expected: boolean`          | The expected value of a [`boolean`][js-boolean] to compare against the result of the `value` check that is passed to the `toBe()` method of `jasmine.Matchers` |
+| `expectationFailOutput: any` | An additional message when the matcher fails, by default, states the `value` should be (or not) the property key |
+
+**Returns:**
+
+The **return value** is an instance of a [`TestingToBeMatchers`](#testingtobematchers).
+
+**Usage:**
+
+```typescript
+// Example usage.
+import { Testing, TestingToBeMatchers } from '@angular-package/testing';
+/**
+ * Create `Testing` instance.
+ */
+const testing = new Testing(true, true);
+const toBe = new TestingToBeMatchers();
+/**
+ * Tests.
+ */
+testing.describe('Expects provided value', () => {
+  let isKey: any;
+  beforeEach(() => (isKey = 'firstName'));
+  testing.describe('to be or not to be', () => {
+    testing.it('`key`', () => toBe.key(isKey).not.key(true));
+  });
+});
+```
+
+<br>
+
+### `TestingToBeMatchers.prototype.null()`
+
+Expects provided `value` to be property key. The method uses [`isNull()`](https://github.com/angular-package/type#isnull) function from the [`@angular-package/type`][type-github-readme].
+
+```typescript
+public null(
+  value: any,
+  expected: jasmine.Expected<boolean> = true,
+  expectationFailOutput: any = `${this.expectationFailOutput} ${
+    this.getNot() === true ? `not` : ``
+  } be \`null\``
+): this {
+  this.toBe(is.null(value), expected, expectationFailOutput);
+  return this;
+}
+```
+
+**Parameters:**
+
+| Name: type                   | Description |
+| :--------------------------- | :---------- |
+| `value: any`                 | The `value` of any type that is checked against `null` and the result of its check is passed to the [`expect()`][jasmine-expect] function of jasmine |
+| `expected: boolean`          | The expected value of a [`boolean`][js-boolean] to compare against the result of the `value` check that is passed to the `toBe()` method of `jasmine.Matchers` |
+| `expectationFailOutput: any` | An additional message when the matcher fails, by default, states the `value` should be (or not) `null` |
+
+**Returns:**
+
+The **return value** is an instance of a [`TestingToBeMatchers`](#testingtobematchers).
+
+**Usage:**
+
+```typescript
+// Example usage.
+import { Testing, TestingToBeMatchers } from '@angular-package/testing';
+/**
+ * Create `Testing` instance.
+ */
+const testing = new Testing(true, true);
+const toBe = new TestingToBeMatchers();
+/**
+ * Tests.
+ */
+testing.describe('Expects provided value', () => {
+  let isNull: any;
+  beforeEach(() => (isNull = null));
+  testing.describe('to be or not to be', () => {
+    testing.it('`null`', () => toBe.null(isNull).not.null(undefined));
+  });
+});
+```
+
+<br>
+
+### `TestingToBeMatchers.prototype.number()`
+
+Expects provided `value` to be [`number`][js-number]. The method uses [`isNumber()`](https://github.com/angular-package/type#isnumber) function from the [`@angular-package/type`][type-github-readme].
+
+```typescript
+public number(
+  value: any,
+  expected: jasmine.Expected<boolean> = true,
+  expectationFailOutput: any = `${this.expectationFailOutput} ${
+    this.getNot() === true ? `not` : ``
+  } be \`number\``
+): this {
+  this.toBe(is.number(value), expected, expectationFailOutput);
+  return this;
+}
+```
+
+**Parameters:**
+
+| Name: type                   | Description |
+| :--------------------------- | :---------- |
+| `value: any`                 | The `value` of any type that is checked against `number` and the result of its check is passed to the [`expect()`][jasmine-expect] function of jasmine |
+| `expected: boolean`          | The expected value of a [`boolean`][js-boolean] to compare against the result of the `value` check that is passed to the `toBe()` method of `jasmine.Matchers` |
+| `expectationFailOutput: any` | An additional message when the matcher fails, by default, states the `value` should be (or not) a `number` |
+
+**Returns:**
+
+The **return value** is an instance of a [`TestingToBeMatchers`](#testingtobematchers).
+
+**Usage:**
+
+```typescript
+// Example usage.
+import { Testing, TestingToBeMatchers } from '@angular-package/testing';
+/**
+ * Create `Testing` instance.
+ */
+const testing = new Testing(true, true);
+const toBe = new TestingToBeMatchers();
+/**
+ * Tests.
+ */
+testing.describe('Expects provided value', () => {
+  let isNumber: any;
+  beforeEach(() => (isNumber = 27));
+  testing.describe('to be or not to be', () => {
+    testing.it('`number`', () => toBe.number(isNumber).not.number(undefined));
+  });
+});
+```
+
+<br>
+
+### `TestingToBeMatchers.prototype.numberBetween()`
+
+Expects provided `value` to be [`number`][js-number] between a range. The method uses [`isNumberBetween()`](https://github.com/angular-package/type#isnumberbetween) function from the [`@angular-package/type`][type-github-readme].
+
+```typescript
+public numberBetween<Min extends number, Max extends number>(
+  value: any,
+  min: Min,
+  max: Max,
+  expected: jasmine.Expected<boolean> = true,
+  expectationFailOutput: any = `${this.expectationFailOutput} ${
+    this.getNot() === true ? `not` : ``
+  } be a number between ${min} to ${max}`
+): this {
+  this.toBe(
+    is.numberBetween(value, min, max),
+    expected,
+    expectationFailOutput
+  );
+  return this;
+}
+```
+
+**Parameters:**
+
+| Name: type                   | Description |
+| :--------------------------- | :---------- |
+| `value: any`                 | The `value` of any type that is checked against `number` of the specified range and the result of its check is passed to the [`expect()`][jasmine-expect] function of jasmine |
+| `min: Min`                   | A `number` of the minimum range of the given `value` |
+| `max: Max`                   | A `number` of the maximum range of the given `value` |
+| `expected: boolean`          | The expected value of a [`boolean`][js-boolean] to compare against the result of the `value` check that is passed to the `toBe()` method of `jasmine.Matchers` |
+| `expectationFailOutput: any` | An additional message when the matcher fails, by default, states the `value` should be (or not) a `number` between minimum to maximum |
+
+**Returns:**
+
+The **return value** is an instance of a [`TestingToBeMatchers`](#testingtobematchers).
+
+**Usage:**
+
+```typescript
+// Example usage.
+import { Testing, TestingToBeMatchers } from '@angular-package/testing';
+/**
+ * Create `Testing` instance.
+ */
+const testing = new Testing(true, true);
+const toBe = new TestingToBeMatchers();
+/**
+ * Tests.
+ */
+testing.describe('Expects provided value', () => {
+  let isNumberBetween: any;
+  let min: any;
+  let max: any;
+  beforeEach(() => {
+    isNumberBetween = 27;
+    min = 26;
+    max = 28;
+  });
+
+  testing.describe('to be or not to be', () => {
+    testing.it(`\`number\` between 26 to 28`, () => toBe.numberBetween(isNumber, min, max).not.number(37, min, max));
+  });
+});
+```
+
+<br>
+
+### `TestingToBeMatchers.prototype.object()`
+
+Expects provided `value` to be an [`object`][js-object]. The method uses [`isObject()`](https://github.com/angular-package/type#isobject) function from the [`@angular-package/type`][type-github-readme].
+
+```typescript
+public object(
+  value: any,
+  expected: jasmine.Expected<boolean> = true,
+  expectationFailOutput: any = `${this.expectationFailOutput} ${
+    this.getNot() === true ? `not` : ``
+  } be an \`object\``
+): this {
+  this.toBe(is.object(value), expected, expectationFailOutput);
+  return this;
+}
+```
+
+**Parameters:**
+
+| Name: type                   | Description |
+| :--------------------------- | :---------- |
+| `value: any`                 | The `value` of any type that is checked against the [`object`][js-object] of the specified range and the result of its check is passed to the [`expect()`][jasmine-expect] function of jasmine |
+| `expected: boolean`          | The expected value of a [`boolean`][js-boolean] to compare against the result of the `value` check that is passed to the `toBe()` method of `jasmine.Matchers` |
+| `expectationFailOutput: any` | An additional message when the matcher fails, by default, states the `value` should be (or not) an [`object`][js-object] |
+
+**Returns:**
+
+The **return value** is an instance of a [`TestingToBeMatchers`](#testingtobematchers).
+
+**Usage:**
+
+```typescript
+// Example usage.
+import { Testing, TestingToBeMatchers } from '@angular-package/testing';
+/**
+ * Create `Testing` instance.
+ */
+const testing = new Testing(true, true);
+const toBe = new TestingToBeMatchers();
+/**
+ * Tests.
+ */
+testing.describe('Expects provided value', () => {
+  let isObject: any;
+  beforeEach(() => isObject = {});
+  testing.describe('to be or not to be', () => {
+    testing.it(`an \`object\``, () => toBe.object(isObject).not.object(undefined));
+  });
+});
+```
+
+<br>
+
+### `TestingToBeMatchers.prototype.objectKey()`
+
+Expects provided `value` to be an [`object`][js-object] with given keys. The method uses [`isObjectKey()`](https://github.com/angular-package/type#isobjectkey) function from the [`@angular-package/type`][type-github-readme].
+
+```typescript
+public objectKey(
+  value: any,
+  key: Key | Key[],
+  expected: jasmine.Expected<boolean> = true,
+  expectationFailOutput: any = `${this.expectationFailOutput} ${
+    this.getNot() === true ? `not` : ``
+  } be an \`object\` with all given keys`
+): this {
+  this.toBe(is.objectKey(value, key), expected, expectationFailOutput);
+  return this;
+}
+```
+
+**Parameters:**
+
+| Name: type                   | Description |
+| :--------------------------- | :---------- |
+| `value: any`                 | The `value` of any type that is checked against the `object` that contains given keys and the result of its check is passed to the [`expect()`][jasmine-expect] function of jasmine |
+| `key: Key | Key[]`           | Property name of `Key` type or an [`array`][js-array] of property names of `Key` type of [`object`][js-object] from the provided `value` |
+| `expected: boolean`          | The expected value of a [`boolean`][js-boolean] to compare against the result of the `value` check that is passed to the `toBe()` method of `jasmine.Matchers` |
+| `expectationFailOutput: any` | An additional message when the matcher fails, by default, states the `value` should be (or not) an [`object`][js-object] with all given keys |
+
+**Returns:**
+
+The **return value** is an instance of a [`TestingToBeMatchers`](#testingtobematchers).
+
+**Usage:**
+
+```typescript
+// Example usage.
+import { Testing, TestingToBeMatchers } from '@angular-package/testing';
+/**
+ * Create `Testing` instance.
+ */
+const testing = new Testing(true, true);
+const toBe = new TestingToBeMatchers();
+/**
+ * Tests.
+ */
+testing.describe('Expects provided value', () => {
+  let isObjectKey: any;
+  beforeEach(() => isObjectKey = { firstName: '', lastName: ''});
+  testing.describe('to be or not to be', () => {
+    testing.it(`an \`object\` with all given keys`, () =>
+      toBe.objectKey(isObjectKey, ['firstName', 'lastName']).not.objectKey(isObjectKey, ['noFirstName']));
+  });
+});
+```
+
+<br>
+
+### `TestingToBeMatchers.prototype.objectKeyIn()`
+
+Expects provided `value` to be an [`object`][js-object] with given keys. The method uses [`isObjectKeyIn()`](https://github.com/angular-package/type#isobjectkeyin) function from the [`@angular-package/type`][type-github-readme].
+
+```typescript
+public objectKeyIn(
+  value: any,
+  key: Key | Key[],
+  expected: jasmine.Expected<boolean> = true,
+  expectationFailOutput: any = `${this.expectationFailOutput} ${
+    this.getNot() === true ? `not` : ``
+  } be an \`object\` with all given keys`
+): this {
+  this.toBe(is.objectKeyIn(value, key), expected, expectationFailOutput);
+  return this;
+}
+```
+
+**Parameters:**
+
+| Name: type                   | Description |
+| :--------------------------- | :---------- |
+| `value: any`                 | The `value` of any type that is checked against the [`object`][js-object] that contains given keys and the result of its check is passed to the [`expect()`][jasmine-expect] function of jasmine |
+| `key: Key | Key[]`           | Property name of `Key` type or an [`array`][js-array] of property names of `Key` type of [`object`][js-object] from the provided `value` |
+| `expected: boolean`          | The expected value of a [`boolean`][js-boolean] to compare against the result of the `value` check that is passed to the `toBe()` method of `jasmine.Matchers` |
+| `expectationFailOutput: any` | An additional message when the matcher fails, by default, states the `value` should be (or not) an [`object`][js-object] with  all given keys |
+
+**Returns:**
+
+The **return value** is an instance of a [`TestingToBeMatchers`](#testingtobematchers).
+
+**Usage:**
+
+```typescript
+// Example usage.
+import { Testing, TestingToBeMatchers } from '@angular-package/testing';
+/**
+ * Create `Testing` instance.
+ */
+const testing = new Testing(true, true);
+const toBe = new TestingToBeMatchers();
+/**
+ * Tests.
+ */
+testing.describe('Expects provided value', () => {
+  let isObjectKeyIn: any;
+  beforeEach(() => isObjectKeyIn = { get firstName(): string { return 'x '; }, lastName: ''});
+  testing.describe('to be or not to be', () =>
+    testing.it(`an \`object\` with all given keys`, () =>
+      toBe.objectKeyIn(isObjectKeyIn, ['firstName', 'lastName']).not.objectKeyIn(isObjectKeyIn, ['noFirstName'])));
+});
+```
+
+<br>
+
+### `TestingToBeMatchers.prototype.objectKeys()`
+
+Expects provided `value` to be an [`object`][js-object] with some of the given keys.  The method uses [`isObjectKeyIn()`](https://github.com/angular-package/type#isobjectkeys) function from the [`@angular-package/type`][type-github-readme].
+
+```typescript
+public objectKeys(
+  value: any,
+  keys: Key[],
+  expected: jasmine.Expected<boolean> = true,
+  expectationFailOutput: any = `${this.expectationFailOutput} ${
+    this.getNot() === true ? `not` : ``
+  } be an \`object\` with some of the given keys`
+): this {
+  this.toBe(is.objectKeys(value, ...keys), expected, expectationFailOutput);
+  return this;
+}
+```
+
+**Parameters:**
+
+| Name: type                   | Description |
+| :--------------------------- | :---------- |
+| `value: any`                 | The `value` of any type that is checked against the [`object`][js-object] that contains some of the given keys and the result of its check is passed to the [`expect()`][jasmine-expect] function of jasmine |
+| `key: Key[]`                 | An [`array`][js-array] of property names of the `Key` type of [`object`][js-object] from the provided `value` |
+| `expected: boolean`          | The expected value of a [`boolean`][js-boolean] to compare against the result of the `value` check that is passed to the `toBe()` method of `jasmine.Matchers` |
+| `expectationFailOutput: any` | An additional message when the matcher fails, by default, states the `value` should be (or not) an [`object`][js-object] with some given keys |
+
+**Returns:**
+
+The **return value** is an instance of a [`TestingToBeMatchers`](#testingtobematchers).
+
+**Usage:**
+
+```typescript
+// Example usage.
+import { Testing, TestingToBeMatchers } from '@angular-package/testing';
+/**
+ * Create `Testing` instance.
+ */
+const testing = new Testing(true, true);
+const toBe = new TestingToBeMatchers();
+/**
+ * Tests.
+ */
+testing.describe('Expects provided value', () => {
+  let isObjectKeys: any;
+  beforeEach(() => isObjectKeys = { get firstName(): string { return 'x '; }, lastName: ''});
+  testing.describe('to be or not to be', () =>
+    testing.it(`an \`object\` with some of the given keys`, () =>
+      toBe.objectKeys(isObjectKeys, ['firstName', 'lastName', 'noFirstName']).not.objectKeys(isObjectKeys, ['noFirstName'])));
+});
+```
+
+<br>
+
+### `TestingToBeMatchers.prototype.regexp()`
+
+Expects provided `value` to be [`RegExp`][js-regexp]. The method uses [`isRegExp()`](https://github.com/angular-package/type#isregexp) function from the [`@angular-package/type`][type-github-readme].
+
+```typescript
+public regexp(
+  value: any,
+  expected: jasmine.Expected<boolean> = true,
+  expectationFailOutput: any = `${this.expectationFailOutput} ${
+    this.getNot() === true ? `not` : ``
+  } be \`regexp\``
+): this {
+  this.toBe(is.regexp(value), expected, expectationFailOutput);
+  return this;
+}
+```
+
+**Parameters:**
+
+| Name: type                   | Description |
+| :--------------------------- | :---------- |
+| `value: any`                 | The `value` of any type that is checked against [`RegExp`][js-regexp] and the result of its check is passed to the [`expect()`][jasmine-expect] function of jasmine |
+| `expected: boolean`          | The expected value of a [`boolean`][js-boolean] to compare against the result of the `value` check that is passed to the `toBe()` method of `jasmine.Matchers` |
+| `expectationFailOutput: any` | An additional message when the matcher fails, by default, states the `value` should be (or not) [`RegExp`][js-regexp] |
+
+**Returns:**
+
+The **return value** is an instance of a [`TestingToBeMatchers`](#testingtobematchers).
+
+**Usage:**
+
+```typescript
+// Example usage.
+import { Testing, TestingToBeMatchers } from '@angular-package/testing';
+/**
+ * Create `Testing` instance.
+ */
+const testing = new Testing(true, true);
+const toBe = new TestingToBeMatchers();
+/**
+ * Tests.
+ */
+testing.describe('Expects provided value', () => {
+  let isRegExp: any;
+  beforeEach(() => isRegExp = /[]/g);
+
+  testing.describe('to be or not to be', () =>
+    testing.it(`\`RegExp\``, () =>
+      toBe.regexp(isRegExp).not.regexp(undefined)));
+});
+```
+
+<br>
+
+### `TestingToBeMatchers.prototype.string()`
+
+Expects provided `value` to be [`string`][js-string]. The method uses [`isString()`](https://github.com/angular-package/type#isstring) function from the [`@angular-package/type`][type-github-readme].
+
+```typescript
+public string(
+  value: any,
+  expected: jasmine.Expected<boolean> = true,
+  expectationFailOutput: any = `${this.expectationFailOutput} ${
+    this.getNot() === true ? `not` : ``
+  } be a \`string\``
+): this {
+  this.toBe(is.string(value), expected, expectationFailOutput);
+  return this;
+}
+```
+
+**Parameters:**
+
+| Name: type                   | Description |
+| :--------------------------- | :---------- |
+| `value: any`                 | The `value` of any type that is checked against a [`string`][js-string] and the result of its check is passed to the [`expect()`][jasmine-expect] function of jasmine |
+| `expected: boolean`          | The expected value of a [`boolean`][js-boolean] to compare against the result of the `value` check that is passed to the `toBe()` method of `jasmine.Matchers` |
+| `expectationFailOutput: any` | An additional message when the matcher fails, by default, states the `value` should be (or not) a [`string`][js-string] |
+
+**Returns:**
+
+The **return value** is an instance of a [`TestingToBeMatchers`](#testingtobematchers).
+
+**Usage:**
+
+```typescript
+// Example usage.
+import { Testing, TestingToBeMatchers } from '@angular-package/testing';
+/**
+ * Create `Testing` instance.
+ */
+const testing = new Testing(true, true);
+const toBe = new TestingToBeMatchers();
+/**
+ * Tests.
+ */
+testing.describe('Expects provided value', () => {
+  let isString: any;
+  beforeEach(() => isString = 'My new string');
+  testing.describe('to be or not to be', () => {
+    testing.it(`\`string\``, () => toBe.string(isString).not.string(undefined));
+  });
+});
+```
+
+<br>
+
+### `TestingToBeMatchers.prototype.stringOfLength()`
+
+Expects provided `value` to be [`string`][js-string] of the length between the given minimum to maximum. The method uses [`isStringLength()`](https://github.com/angular-package/type#isstringlength) function from the [`@angular-package/type`][type-github-readme].
+
+```typescript
+public stringOfLength<Min extends number, Max extends number>(
+  value: any,
+  min: Min,
+  max: Max,
+  expected: jasmine.Expected<boolean> = true,
+  expectationFailOutput: any = `${this.expectationFailOutput} ${
+    this.getNot() === true ? `not` : ``
+  } be a \`string\` of the length between the given ${min} to ${max}`
+): this {
+  this.toBe(
+    is.stringLength(value, min, max),
+    expected,
+    expectationFailOutput
+  );
+  return this;
+}
+```
+
+**Parameters:**
+
+| Name: type                   | Description |
+| :--------------------------- | :---------- |
+| `value: any`                 | The `value` of any type that is checked against a [`string`][js-string] of the specified length and the result of its check is passed to the [`expect()`][jasmine-expect] function of jasmine |
+| `min: Min`                   | Minimum length of the given `value` of a [`number`][js-number] type |
+| `max: Max`                   | The maximum length of the given `value` of a [`number`][js-number] type |
+| `expected: boolean`          | The expected value of a [`boolean`][js-boolean] to compare against the result of the `value` check that is passed to the `toBe()` method of `jasmine.Matchers` |
+| `expectationFailOutput: any` | An additional message when the matcher fails, by default, states the `value` should be (or not) a [`string`][js-string] of the length between the given minimum to maximum |
+
+**Returns:**
+
+The **return value** is an instance of a [`TestingToBeMatchers`](#testingtobematchers).
+
+**Usage:**
+
+```typescript
+// Example usage.
+import { Testing, TestingToBeMatchers } from '@angular-package/testing';
+/**
+ * Create `Testing` instance.
+ */
+const testing = new Testing(true, true);
+const toBe = new TestingToBeMatchers();
+/**
+ * Tests.
+ */
+testing.describe('Expects provided value', () => {
+  let isStringOfLength: any;
+  let min: any;
+  let max: any;
+  beforeEach(() => {
+    isStringOfLength = 'My new string, My new string';
+    min = 26;
+    max = 28;
+  });
+  testing.describe('to be or not to be', () => {
+    testing.it(`a \`string\` between the given length`, () =>
+      toBe.stringOfLength(isStringOfLength, min, max).not.stringOfLength(undefined, min, max));
+  });
+});
+```
+
+<br>
+
+### `TestingToBeMatchers.prototype.symbol()`
+
+Expects provided `value` to be [`symbol`][js-symbol]. The method uses [`isSymbol()`](https://github.com/angular-package/type#issymbol) function from the [`@angular-package/type`][type-github-readme].
+
+```typescript
+public symbol(
+  value: any,
+  expected: jasmine.Expected<boolean> = true,
+  expectationFailOutput: any = `${this.expectationFailOutput} ${
+    this.getNot() === true ? `not` : ``
+  } be a \`symbol\``
+): this {
+  this.toBe(is.symbol(value), expected, expectationFailOutput);
+  return this;
+}
+```
+
+**Parameters:**
+
+| Name: type                   | Description |
+| :--------------------------- | :---------- |
+| `value: any`                 | The `value` of any type that is checked against a [`symbol`][js-symbol] and the result of its check is passed to the [`expect()`][jasmine-expect] function of jasmine |
+| `expected: boolean`          | The expected value of a [`boolean`][js-boolean] to compare against the result of the `value` check that is passed to the `toBe()` method of `jasmine.Matchers` |
+| `expectationFailOutput: any` | An additional message when the matcher fails, by default, states the `value` should be (or not) a [`symbol`][js-symbol] |
+
+**Returns:**
+
+The **return value** is an instance of a [`TestingToBeMatchers`](#testingtobematchers).
+
+**Usage:**
+
+```typescript
+// Example usage.
+import { Testing, TestingToBeMatchers } from '@angular-package/testing';
+/**
+ * Create `Testing` instance.
+ */
+const testing = new Testing(true, true);
+const toBe = new TestingToBeMatchers();
+/**
+ * Tests.
+ */
+testing.describe('Expects provided value', () => {
+  let isSymbol: any;
+  beforeEach(() => isSymbol = Symbol('firstName'));
+  testing.describe('to be or not to be', () => 
+    testing.it(`a \`symbol\``, () => toBe.symbol(isSymbol).not.symbol(undefined)));
+});
+```
+
+<br>
+
+### `TestingToBeMatchers.prototype.true()`
+
+Expects provided `value` to be `true`. The method uses [`isTrue()`](https://github.com/angular-package/type#istrue) function from the [`@angular-package/type`][type-github-readme].
+
+```typescript
+public true(
+  value: any,
+  expected: jasmine.Expected<boolean> = true,
+  expectationFailOutput: any = `${this.expectationFailOutput} ${
+    this.getNot() === true ? `not` : ``
+  } be \`true\``
+): this {
+  this.toBe(is.true(value), expected, expectationFailOutput);
+  return this;
+}
+```
+
+**Parameters:**
+
+| Name: type                   | Description |
+| :--------------------------- | :---------- |
+| `value: any`                 | The `value` of any type that is checked against `true` and the result of its check is passed to the [`expect()`][jasmine-expect] function of jasmine |
+| `expected: boolean`          | The expected value of a [`boolean`][js-boolean] to compare against the result of the `value` check that is passed to the `toBe()` method of `jasmine.Matchers` |
+| `expectationFailOutput: any` | An additional message when the matcher fails, by default, states the `value` should be (or not) `true` |
+
+**Returns:**
+
+The **return value** is an instance of a [`TestingToBeMatchers`](#testingtobematchers).
+
+**Usage:**
+
+```typescript
+// Example usage.
+import { Testing, TestingToBeMatchers } from '@angular-package/testing';
+/**
+ * Create `Testing` instance.
+ */
+const testing = new Testing(true, true);
+const toBe = new TestingToBeMatchers();
+/**
+ * Tests.
+ */
+testing.describe('Expects provided value', () => {
+  let isTrue: any;
+  beforeEach(() => isTrue = true);
+  testing.describe('to be or not to be', () =>
+    testing.it(`\`true\``, () => toBe.true(isTrue).not.true(false)));
+});
+```
+
+<br>
+
+### `TestingToBeMatchers.prototype.undefined()`
+
+Expects provided `value` to be `undefined`. The method uses [`isUndefined()`](https://github.com/angular-package/type#isundefined) function from the [`@angular-package/type`][type-github-readme].
+
+```typescript
+public undefined(
+  value: any,
+  expected: jasmine.Expected<boolean> = true,
+  expectationFailOutput: any = `${this.expectationFailOutput} ${
+    this.getNot() === true ? `not` : ``
+  } be \`undefined\``
+): this {
+  this.toBe(is.undefined(value), expected, expectationFailOutput);
+  return this;
+}
+```
+
+**Parameters:**
+
+| Name: type                   | Description |
+| :--------------------------- | :---------- |
+| `value: any`                 | The `value` of any type that is checked against `undefined` and the result of its check is passed to the [`expect()`][jasmine-expect] function of jasmine |
+| `expected: boolean`          | The expected value of a [`boolean`][js-boolean] to compare against the result of the `value` check that is passed to the `toBe()` method of `jasmine.Matchers` |
+| `expectationFailOutput: any` | An additional message when the matcher fails, by default, states the `value` should be (or not) `undefined` |
+
+**Returns:**
+
+The **return value** is an instance of a [`TestingToBeMatchers`](#testingtobematchers).
+
+**Usage:**
+
+```typescript
+// Example usage.
+import { Testing, TestingToBeMatchers } from '@angular-package/testing';
+/**
+ * Create `Testing` instance.
+ */
+const testing = new Testing(true, true);
+const toBe = new TestingToBeMatchers();
+/**
+ * Tests.
+ */
+testing.describe('Expects provided value', () => {
+  let isUndefined: any;
+  beforeEach(() => isUndefined = undefined);
+  testing.describe('to be or not to be', () => 
+    testing.it(`\`undefined\``, () => toBe.undefined(isUndefined).not.undefined(null)));
+});
 ```
 
 <br>

--- a/README.md
+++ b/README.md
@@ -1874,9 +1874,9 @@ Matchers that use the `toBe()` method of `jasmine.Matchers`.
 | [`number()`](#testingtobematchersprototypenumber)                 | Expects provided `value` to be a `number` |
 | [`numberBetween()`](#testingtobematchersprototypenumberbetween)   | Expects provided `value` to be a `number` between minimum and maximum |
 | [`object()`](#testingtobematchersprototypeobject)                 | Expects provided `value` to be an `object` |
-| [`objectKey()`](#testingtobematchersprototypeobjectkey)           | Expects provided `value` to be an `object` with the given key or keys by using the [`hasOwnProperty`][js-hasownproperty] method of [`Object`][js-object] |
-| [`objectKeyIn()`](#testingtobematchersprototypeobjectkeyin)       | Expects provided `value` to be an `object` with the given key or keys by using the [`in`][js-in-operator] operator |
-| [`objectKeys()`](#testingtobematchersprototypeobjectkeys)         | Expects provided `value` to be an `object` with some of the given keys by using the [`hasOwnProperty`][js-hasownproperty] method of [`Object`][js-object] |
+| [`objectKey()`](#testingtobematchersprototypeobjectkey)           | Expects provided `value` to be an `object` with the given keys by using the [`hasOwnProperty`][js-hasownproperty] method of [`Object`][js-object] |
+| [`objectKeyIn()`](#testingtobematchersprototypeobjectkeyin)       | Expects provided `value` to be an `object` with the given keys by using the [`in`][js-in-operator] operator |
+| [`objectKeys()`](#testingtobematchersprototypeobjectkeys)         | Expects provided `value` to be an `object` with some given keys by using the [`hasOwnProperty`][js-hasownproperty] method of [`Object`][js-object] |
 | [`regexp()`](#testingtobematchersprototyperegexp)                 | Expects provided `value` to be [`RegExp`][js-regexp] |
 | [`string()`](#testingtobematchersprototypestring)                 | Expects provided `value` to be a [`string`][js-string] |
 | [`stringOfLength()`](#testingtobematchersprototypestringoflength) | Expects provided `value` to be a [`string`][js-string] of the specified minimum and maximum length |

--- a/README.md
+++ b/README.md
@@ -1874,9 +1874,9 @@ Matchers that use the `toBe()` method of `jasmine.Matchers`.
 | [`number()`](#testingtobematchersprototypenumber)                 | Expects provided `value` to be a `number` |
 | [`numberBetween()`](#testingtobematchersprototypenumberbetween)   | Expects provided `value` to be a `number` between minimum and maximum |
 | [`object()`](#testingtobematchersprototypeobject)                 | Expects provided `value` to be an `object` |
-| [`objectKey()`](#testingtobematchersprototypeobjectkey)           | Expects provided `value` to be an `object` with the given keys by using the [`hasOwnProperty`][js-hasownproperty] method of [`Object`][js-object] |
+| [`objectKey()`](#testingtobematchersprototypeobjectkey)           | Expects provided `value` to be an `object` with the given keys by using the [`hasOwnProperty`][js-hasownproperty] method of the [`Object`][js-object] |
 | [`objectKeyIn()`](#testingtobematchersprototypeobjectkeyin)       | Expects provided `value` to be an `object` with the given keys by using the [`in`][js-in-operator] operator |
-| [`objectKeys()`](#testingtobematchersprototypeobjectkeys)         | Expects provided `value` to be an `object` with some given keys by using the [`hasOwnProperty`][js-hasownproperty] method of [`Object`][js-object] |
+| [`objectKeys()`](#testingtobematchersprototypeobjectkeys)         | Expects provided `value` to be an `object` with some given keys by using the [`hasOwnProperty`][js-hasownproperty] method of the [`Object`][js-object] |
 | [`regexp()`](#testingtobematchersprototyperegexp)                 | Expects provided `value` to be [`RegExp`][js-regexp] |
 | [`string()`](#testingtobematchersprototypestring)                 | Expects provided `value` to be a [`string`][js-string] |
 | [`stringOfLength()`](#testingtobematchersprototypestringoflength) | Expects provided `value` to be a [`string`][js-string] of the specified minimum and maximum length |

--- a/README.md
+++ b/README.md
@@ -1865,7 +1865,7 @@ Matchers that use the `toBe()` method of `jasmine.Matchers`.
 | [`boolean()`](#testingtobematchersprototypeboolean)               | Expects provided `value` to be a [`boolean`][js-boolean] type |
 | [`class()`](#testingtobematchersprototypeclass)                   | Expects provided `value` to be a [`class`][js-classes] |
 | [`date()`](#testingtobematchersprototypedate)                     | Expects provided `value` to be a [`Date`][js-date] |
-| [`defined()`](#testingtobematchersprototypdefined)                | Expects provided `value` to be defined |
+| [`defined()`](#testingtobematchersprototypedefined)               | Expects provided `value` to be defined |
 | [`false()`](#testingtobematchersprototypefalse)                   | Expects provided `value` to be [`false`][js-boolean] |
 | [`function()`](#testingtobematchersprototypefunction)             | Expects provided `value` to be [`function`][js-function] |
 | [`instance()`](#testingtobematchersprototypeinstance)             | Expects provided `value` to be an instance of the given class from the `constructor` |
@@ -1887,6 +1887,8 @@ Matchers that use the `toBe()` method of `jasmine.Matchers`.
 <br>
 
 ### `TestingToBeMatchers.prototype.array()`
+
+![new][new]
 
 Expects provided `value` to be an [`array`][js-array]. The method uses [`isArray()`](https://github.com/angular-package/type#isarray) function from the [`@angular-package/type`][type-github-readme].
 
@@ -1942,6 +1944,8 @@ testing.describe('Expects provided value', () => {
 
 ### `TestingToBeMatchers.prototype.bigint()`
 
+![new][new]
+
 Expects provided `value` to be [`bigint`][js-bigint] type. The method uses [`isBigInt()`](https://github.com/angular-package/type#isbigint) function from the [`@angular-package/type`][type-github-readme].
 
 ```typescript
@@ -1961,7 +1965,7 @@ public bigint(
 
 | Name: type                   | Description |
 | :--------------------------- | :---------- |
-| `value: Value`               | The `value` of any type that is checked against the [`bigint`][js-bigint], and the result of its check is passed to the [`expect()`][jasmine-expect] function of jasmine |
+| `value: any`                 | The `value` of any type that is checked against the [`bigint`][js-bigint] and the result of its check is passed to the [`expect()`][jasmine-expect] function of jasmine |
 | `expected: boolean`          | The expected value of a [`boolean`][js-boolean] to compare against the result of the `value` check that is passed to the `toBe()` method of `jasmine.Matchers` |
 | `expectationFailOutput: any` | An additional message when the matcher fails, by default, states the `value` should be (or not) [`bigint`][js-bigint]  |
 
@@ -1996,6 +2000,8 @@ testing.describe('Expects provided value', () => {
 
 ### `TestingToBeMatchers.prototype.boolean()`
 
+![new][new]
+
 Expects provided `value` to be [`boolean`][js-boolean]. The method uses [`isBoolean()`](https://github.com/angular-package/type#isboolean) function from the [`@angular-package/type`][type-github-readme].
 
 ```typescript
@@ -2015,7 +2021,7 @@ public boolean(
 
 | Name: type                   | Description |
 | :--------------------------- | :---------- |
-| `value: any`                 | The `value` of any type that is checked against the [`boolean`][js-boolean], and the result of its check is passed to the [`expect()`][jasmine-expect] function of jasmine |
+| `value: any`                 | The `value` of any type that is checked against the [`boolean`][js-boolean] and the result of its check is passed to the [`expect()`][jasmine-expect] function of jasmine |
 | `expected: boolean`          | The expected value of a [`boolean`][js-boolean] to compare against the result of the `value` check that is passed to the `toBe()` method of `jasmine.Matchers` |
 | `expectationFailOutput: any` | An additional message when the matcher fails, by default, states the `value` should be (or not) [`boolean`][js-boolean]  |
 
@@ -2050,6 +2056,8 @@ testing.describe('Expects provided value', () => {
 
 ### `TestingToBeMatchers.prototype.class()`
 
+![new][new]
+
 Expects provided `value` to be [`class`][js-classes]. The method uses [`isClass()`](https://github.com/angular-package/type#isclass) function from the [`@angular-package/type`][type-github-readme].
 
 ```typescript
@@ -2069,7 +2077,7 @@ public class(
 
 | Name: type                   | Description |
 | :--------------------------- | :---------- |
-| `value: any`                 | The `value` of any type that is checked against the [`class`][js-classes], and the result of its check is passed to the [`expect()`][jasmine-expect] function of jasmine |
+| `value: any`                 | The `value` of any type that is checked against the [`class`][js-classes] and the result of its check is passed to the [`expect()`][jasmine-expect] function of jasmine |
 | `expected: boolean`          | The expected value of a [`boolean`][js-boolean] to compare against the result of the `value` check that is passed to the `toBe()` method of `jasmine.Matchers` |
 | `expectationFailOutput: any` | An additional message when the matcher fails, by default, states the `value` should be (or not) [`class`][js-classes]  |
 
@@ -2103,6 +2111,8 @@ testing.describe('Expects provided value', () => {
 
 ### `TestingToBeMatchers.prototype.date()`
 
+![new][new]
+
 Expects provided `value` to be a [`date`][js-date]. The method uses [`isDate()`](https://github.com/angular-package/type#isdate) function from the [`@angular-package/type`][type-github-readme].
 
 ```typescript
@@ -2122,7 +2132,7 @@ public date(
 
 | Name: type                   | Description |
 | :--------------------------- | :---------- |
-| `value: any`                 | The `value` of any type that is checked against [`date`][js-date], and the result of its check is passed to the [`expect()`][jasmine-expect] function of jasmine |
+| `value: any`                 | The `value` of any type that is checked against [`date`][js-date] and the result of its check is passed to the [`expect()`][jasmine-expect] function of jasmine |
 | `expected: boolean`          | The expected value of a [`boolean`][js-boolean] to compare against the result of the `value` check that is passed to the `toBe()` method of `jasmine.Matchers` |
 | `expectationFailOutput: any` | An additional message when the matcher fails, by default, states the `value` should be (or not) a [`date`][js-date]  |
 
@@ -2156,6 +2166,8 @@ testing.describe('Expects provided value', () => {
 
 ### `TestingToBeMatchers.prototype.defined()`
 
+![new][new]
+
 Expects provided `value` to be defined. The method uses [`isDefined()`](https://github.com/angular-package/type#isdefined) function from the [`@angular-package/type`][type-github-readme].
 
 ```typescript
@@ -2175,7 +2187,7 @@ public defined(
 
 | Name: type                   | Description |
 | :--------------------------- | :---------- |
-| `value: any`                 | The `value` of any type that is checked to the defined and the result of its check is passed to the [`expect()`][jasmine-expect] function of jasmine |
+| `value: any`                 | The `value` of any type that is checked against defined and the result of its check is passed to the [`expect()`][jasmine-expect] function of jasmine |
 | `expected: boolean`          | The expected value of a [`boolean`][js-boolean] to compare against the result of the `value` check that is passed to the `toBe()` method of `jasmine.Matchers` |
 | `expectationFailOutput: any` | An additional message when the matcher fails, by default, states the `value` should be (or not) defined  |
 
@@ -2207,6 +2219,8 @@ testing.describe('Expects provided value', () => {
 <br>
 
 ### `TestingToBeMatchers.prototype.false()`
+
+![new][new]
 
 Expects provided `value` to be `false`. The method uses [`isFalse()`](https://github.com/angular-package/type#isfalse) function from the [`@angular-package/type`][type-github-readme].
 
@@ -2261,6 +2275,8 @@ testing.describe('Expects provided value', () => {
 
 ### `TestingToBeMatchers.prototype.function()`
 
+![new][new]
+
 Expects provided `value` to be [`function`][js-function]. The method uses [`isFunction()`](https://github.com/angular-package/type#isfunction) function from the [`@angular-package/type`][type-github-readme].
 
 ```typescript
@@ -2313,6 +2329,8 @@ testing.describe('Expects provided value', () => {
 <br>
 
 ### `TestingToBeMatchers.prototype.instance()`
+
+![new][new]
 
 Expects provided `value` to be [`function`][js-function]. The method uses [`isFunction()`](https://github.com/angular-package/type#isfunction) function from the [`@angular-package/type`][type-github-readme].
 
@@ -2371,6 +2389,8 @@ testing.describe('Expects provided value', () => {
 
 ### `TestingToBeMatchers.prototype.key()`
 
+![new][new]
+
 Expects provided `value` to be property key. The method uses [`isKey()`](https://github.com/angular-package/type#iskey) function from the [`@angular-package/type`][type-github-readme].
 
 ```typescript
@@ -2423,6 +2443,8 @@ testing.describe('Expects provided value', () => {
 <br>
 
 ### `TestingToBeMatchers.prototype.null()`
+
+![new][new]
 
 Expects provided `value` to be property key. The method uses [`isNull()`](https://github.com/angular-package/type#isnull) function from the [`@angular-package/type`][type-github-readme].
 
@@ -2477,6 +2499,8 @@ testing.describe('Expects provided value', () => {
 
 ### `TestingToBeMatchers.prototype.number()`
 
+![new][new]
+
 Expects provided `value` to be [`number`][js-number]. The method uses [`isNumber()`](https://github.com/angular-package/type#isnumber) function from the [`@angular-package/type`][type-github-readme].
 
 ```typescript
@@ -2529,6 +2553,8 @@ testing.describe('Expects provided value', () => {
 <br>
 
 ### `TestingToBeMatchers.prototype.numberBetween()`
+
+![new][new]
 
 Expects provided `value` to be [`number`][js-number] between a range. The method uses [`isNumberBetween()`](https://github.com/angular-package/type#isnumberbetween) function from the [`@angular-package/type`][type-github-readme].
 
@@ -2598,6 +2624,8 @@ testing.describe('Expects provided value', () => {
 
 ### `TestingToBeMatchers.prototype.object()`
 
+![new][new]
+
 Expects provided `value` to be an [`object`][js-object]. The method uses [`isObject()`](https://github.com/angular-package/type#isobject) function from the [`@angular-package/type`][type-github-readme].
 
 ```typescript
@@ -2651,6 +2679,8 @@ testing.describe('Expects provided value', () => {
 
 ### `TestingToBeMatchers.prototype.objectKey()`
 
+![new][new]
+
 Expects provided `value` to be an [`object`][js-object] with given keys. The method uses [`isObjectKey()`](https://github.com/angular-package/type#isobjectkey) function from the [`@angular-package/type`][type-github-readme].
 
 ```typescript
@@ -2672,7 +2702,7 @@ public objectKey(
 | Name: type                   | Description |
 | :--------------------------- | :---------- |
 | `value: any`                 | The `value` of any type that is checked against the `object` that contains given keys and the result of its check is passed to the [`expect()`][jasmine-expect] function of jasmine |
-| `key: Key | Key[]`           | Property name of `Key` type or an [`array`][js-array] of property names of `Key` type of [`object`][js-object] from the provided `value` |
+| `key: Key \| Key[]`          | Property name of [`Key`](https://github.com/angular-package/type#key) type or an [`array`][js-array] of property names of [`Key`](https://github.com/angular-package/type#key) type of [`object`][js-object] from the provided `value` |
 | `expected: boolean`          | The expected value of a [`boolean`][js-boolean] to compare against the result of the `value` check that is passed to the `toBe()` method of `jasmine.Matchers` |
 | `expectationFailOutput: any` | An additional message when the matcher fails, by default, states the `value` should be (or not) an [`object`][js-object] with all given keys |
 
@@ -2707,6 +2737,8 @@ testing.describe('Expects provided value', () => {
 
 ### `TestingToBeMatchers.prototype.objectKeyIn()`
 
+![new][new]
+
 Expects provided `value` to be an [`object`][js-object] with given keys. The method uses [`isObjectKeyIn()`](https://github.com/angular-package/type#isobjectkeyin) function from the [`@angular-package/type`][type-github-readme].
 
 ```typescript
@@ -2728,7 +2760,7 @@ public objectKeyIn(
 | Name: type                   | Description |
 | :--------------------------- | :---------- |
 | `value: any`                 | The `value` of any type that is checked against the [`object`][js-object] that contains given keys and the result of its check is passed to the [`expect()`][jasmine-expect] function of jasmine |
-| `key: Key | Key[]`           | Property name of `Key` type or an [`array`][js-array] of property names of `Key` type of [`object`][js-object] from the provided `value` |
+| `key: Key \| Key[]`          | Property name of [`Key`](https://github.com/angular-package/type#key) type or an [`array`][js-array] of property names of [`Key`](https://github.com/angular-package/type#key) type of [`object`][js-object] from the provided `value` |
 | `expected: boolean`          | The expected value of a [`boolean`][js-boolean] to compare against the result of the `value` check that is passed to the `toBe()` method of `jasmine.Matchers` |
 | `expectationFailOutput: any` | An additional message when the matcher fails, by default, states the `value` should be (or not) an [`object`][js-object] with  all given keys |
 
@@ -2762,6 +2794,8 @@ testing.describe('Expects provided value', () => {
 
 ### `TestingToBeMatchers.prototype.objectKeys()`
 
+![new][new]
+
 Expects provided `value` to be an [`object`][js-object] with some of the given keys.  The method uses [`isObjectKeyIn()`](https://github.com/angular-package/type#isobjectkeys) function from the [`@angular-package/type`][type-github-readme].
 
 ```typescript
@@ -2783,7 +2817,7 @@ public objectKeys(
 | Name: type                   | Description |
 | :--------------------------- | :---------- |
 | `value: any`                 | The `value` of any type that is checked against the [`object`][js-object] that contains some of the given keys and the result of its check is passed to the [`expect()`][jasmine-expect] function of jasmine |
-| `key: Key[]`                 | An [`array`][js-array] of property names of the `Key` type of [`object`][js-object] from the provided `value` |
+| `key: Key[]`                 | An [`array`][js-array] of property names of the [`Key`](https://github.com/angular-package/type#key) type of [`object`][js-object] from the provided `value` |
 | `expected: boolean`          | The expected value of a [`boolean`][js-boolean] to compare against the result of the `value` check that is passed to the `toBe()` method of `jasmine.Matchers` |
 | `expectationFailOutput: any` | An additional message when the matcher fails, by default, states the `value` should be (or not) an [`object`][js-object] with some given keys |
 
@@ -2816,6 +2850,8 @@ testing.describe('Expects provided value', () => {
 <br>
 
 ### `TestingToBeMatchers.prototype.regexp()`
+
+![new][new]
 
 Expects provided `value` to be [`RegExp`][js-regexp]. The method uses [`isRegExp()`](https://github.com/angular-package/type#isregexp) function from the [`@angular-package/type`][type-github-readme].
 
@@ -2871,6 +2907,8 @@ testing.describe('Expects provided value', () => {
 
 ### `TestingToBeMatchers.prototype.string()`
 
+![new][new]
+
 Expects provided `value` to be [`string`][js-string]. The method uses [`isString()`](https://github.com/angular-package/type#isstring) function from the [`@angular-package/type`][type-github-readme].
 
 ```typescript
@@ -2923,6 +2961,8 @@ testing.describe('Expects provided value', () => {
 <br>
 
 ### `TestingToBeMatchers.prototype.stringOfLength()`
+
+![new][new]
 
 Expects provided `value` to be [`string`][js-string] of the length between the given minimum to maximum. The method uses [`isStringLength()`](https://github.com/angular-package/type#isstringlength) function from the [`@angular-package/type`][type-github-readme].
 
@@ -2992,6 +3032,8 @@ testing.describe('Expects provided value', () => {
 
 ### `TestingToBeMatchers.prototype.symbol()`
 
+![new][new]
+
 Expects provided `value` to be [`symbol`][js-symbol]. The method uses [`isSymbol()`](https://github.com/angular-package/type#issymbol) function from the [`@angular-package/type`][type-github-readme].
 
 ```typescript
@@ -3044,6 +3086,8 @@ testing.describe('Expects provided value', () => {
 
 ### `TestingToBeMatchers.prototype.true()`
 
+![new][new]
+
 Expects provided `value` to be `true`. The method uses [`isTrue()`](https://github.com/angular-package/type#istrue) function from the [`@angular-package/type`][type-github-readme].
 
 ```typescript
@@ -3095,6 +3139,8 @@ testing.describe('Expects provided value', () => {
 <br>
 
 ### `TestingToBeMatchers.prototype.undefined()`
+
+![new][new]
 
 Expects provided `value` to be `undefined`. The method uses [`isUndefined()`](https://github.com/angular-package/type#isundefined) function from the [`@angular-package/type`][type-github-readme].
 

--- a/README.md
+++ b/README.md
@@ -2350,6 +2350,10 @@ public instance<Type>(
 
 **Generic type variables:**
 
+| Name   | Description  |
+| :----- | :----------- |
+| `Type` | A generic variable by default of value captured from a given `constructor` |
+
 **Parameters:**
 
 | Name: type                       | Description |
@@ -2796,7 +2800,7 @@ testing.describe('Expects provided value', () => {
 
 ![new][new]
 
-Expects provided `value` to be an [`object`][js-object] with some of the given keys.  The method uses [`isObjectKeyIn()`](https://github.com/angular-package/type#isobjectkeys) function from the [`@angular-package/type`][type-github-readme].
+Expects provided `value` to be an [`object`][js-object] with some of the given keys.  The method uses [`isObjectKeys()`](https://github.com/angular-package/type#isobjectkeys) function from the [`@angular-package/type`][type-github-readme].
 
 ```typescript
 public objectKeys(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@angular-package/testing",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@angular-package/testing",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "dependencies": {
         "tslib": "^2.2.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@angular-package/testing",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Support for testing other packages.",
   "author": "Angular Package <angular-package@wvvw.dev> (https://wvvw.dev)",
   "homepage": "https://github.com/angular-package/testing#readme",

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,1 +1,2 @@
 export { Testing } from './testing.class';
+export { TestingToBeMatchers } from './testing-tobe-matchers.class';

--- a/src/lib/testing-expect.class.ts
+++ b/src/lib/testing-expect.class.ts
@@ -1,7 +1,7 @@
 //
 import { is } from '@angular-package/type';
 /**
- * Manages the `expect()` function of jasmine.
+ * Manages `expect()` function of jasmine.
  */
 export abstract class TestingExpect {
   /**

--- a/src/lib/testing-expect.class.ts
+++ b/src/lib/testing-expect.class.ts
@@ -1,0 +1,48 @@
+//
+import { is } from '@angular-package/type';
+/**
+ * Manages the `expect()` function of jasmine.
+ */
+export abstract class TestingExpect {
+  /**
+   * Invert the matcher.
+   */
+  get not(): this {
+    this.#not = true;
+    return this;
+  }
+
+  /**
+   * Privately stored state of invert the matcher.
+   */
+  #not = false;
+
+  /**
+   * Sets a state of a `boolean` type to invert the matcher .
+   * @param not Value of a `boolean` type indicating a state to invert the matcher.
+   * @returns The return value is an instance of a child class.
+   */
+  protected setNot(not: boolean): this {
+    if (is.boolean(not)) {
+      this.#not = not;
+    }
+    return this;
+  }
+
+  /**
+   * Returns the state of invert the matcher.
+   * @returns The return value is a state of invert the matcher.
+   */
+  protected getNot(): boolean {
+    return this.#not;
+  }
+
+  /**
+   * Wrapper method for the `expect()` function of jasmine.
+   * @param actual The value of a type captured from the `actual` that is passed to the `expect()` function of jasmine.
+   * @returns The return value is an `object` of jasmine matchers to use.
+   */
+  protected expect<Actual>(actual: Actual): jasmine.Matchers<Actual> {
+    return is.true(this.#not) ? expect(actual).not : expect(actual);
+  }
+}

--- a/src/lib/testing-tobe-matchers.class.ts
+++ b/src/lib/testing-tobe-matchers.class.ts
@@ -1,0 +1,531 @@
+//
+import { is, Constructor, Key } from '@angular-package/type';
+//
+import { TestingExpect } from './testing-expect.class';
+/**
+ * Matchers that use the `toBe()` method of jasmine.
+ */
+export class TestingToBeMatchers extends TestingExpect {
+  /**
+   * The Default message for the expectation fails.
+   */
+  private expectationFailOutput = `The expected value should`;
+
+  /**
+   * Expects provided `value` to be an `array`. The method uses `isArray()` function from the `@angular-package/type`.
+   * @param value The `value` of any type that is checked against the `array` and the result of its check is passed to the `expect()`
+   * function of jasmine.
+   * @param expected The expected `value` of a `boolean` to compare against the result of the `value` check that is passed to the `toBe()`
+   * method of `jasmine.Matchers`.
+   * @param expectationFailOutput An additional message when the matcher fails, by default, states the `value` should be (or not) an
+   * `array`.
+   * @returns The return value is an instance of `TestingToBeMatchers`.
+   */
+  public array(
+    value: any,
+    expected: jasmine.Expected<boolean> = true,
+    expectationFailOutput: any = `${this.expectationFailOutput} ${
+      this.getNot() === true ? `not` : ``
+    } be an \`array\``
+  ): this {
+    this.toBe(is.array(value), expected, expectationFailOutput);
+    return this;
+  }
+
+  /**
+   * Expects provided `value` to be `bigint` type. The method uses `isBigInt()` function from the `@angular-package/type`.
+   * @param value The `value` of any type that is checked against `bigint` and the result of its check is passed to the `expect()`
+   * function of jasmine.
+   * @param expected The expected `value` of a `boolean` to compare against the result of the `value` check that is passed to the `toBe()`
+   * method of `jasmine.Matchers`.
+   * @param expectationFailOutput An additional message when the matcher fails, by default, states the `value` should be (or not) `bigint`.
+   * @returns The return value is an instance of `TestingToBeMatchers`.
+   */
+  public bigint(
+    value: any,
+    expected: jasmine.Expected<boolean> = true,
+    expectationFailOutput: any = `${this.expectationFailOutput} ${
+      this.getNot() === true ? `not` : ``
+    } be \`bigint\``
+  ): this {
+    this.toBe(is.bigint(value), expected, expectationFailOutput);
+    return this;
+  }
+
+  /**
+   * Expects provided `value` to be `boolean` type. The method uses `isBoolean()` function from the `@angular-package/type`.
+   * @param value The `value` of any type that is checked against `boolean` and the result of its check is passed to the `expect()`
+   * function of jasmine.
+   * @param expected The expected `value` of a `boolean` to compare against the result of the `value` check that is passed to the `toBe()`
+   * method of `jasmine.Matchers`.
+   * @param expectationFailOutput An additional message when the matcher fails, by default, states the `value` should be (or not)
+   * `boolean`.
+   * @returns The return value is an instance of `TestingToBeMatchers`.
+   */
+  public boolean(
+    value: any,
+    expected: jasmine.Expected<boolean> = true,
+    expectationFailOutput: any = `${this.expectationFailOutput} ${
+      this.getNot() === true ? `not` : ``
+    } be \`boolean\``
+  ): this {
+    this.toBe(is.boolean(value), expected, expectationFailOutput);
+    return this;
+  }
+
+  /**
+   * Expects provided `value` to be `class`. The method uses `isClass()` function from the `@angular-package/type`.
+   * @param value The `value` of any type that is checked against the `class` and the result of its check is passed to the `expect()`
+   * function of jasmine.
+   * @param expected The expected `value` of a `boolean` to compare against the result of the `value` check that is passed to the `toBe()`
+   * method of `jasmine.Matchers`.
+   * @param expectationFailOutput An additional message when the matcher fails, by default, states the `value` should be (or not) `class`.
+   * @returns The return value is an instance of `TestingToBeMatchers`.
+   */
+  public class(
+    value: any,
+    expected: jasmine.Expected<boolean> = true,
+    expectationFailOutput: any = `${this.expectationFailOutput} ${
+      this.getNot() === true ? `not` : ``
+    } be \`class\``
+  ): this {
+    this.toBe(is.class(value), expected, expectationFailOutput);
+    return this;
+  }
+
+  /**
+   * Expects provided `value` to be a `Date`. The method uses `isDate()` function from the `@angular-package/type`.
+   * @param value The `value` of any type that is checked against `date` and the result of its check is passed to the `expect()`
+   * function of jasmine.
+   * @param expected The expected `value` of a `boolean` to compare against the result of the `value` check that is passed to the `toBe()`
+   * method of `jasmine.Matchers`.
+   * @param expectationFailOutput An additional message when the matcher fails, by default, states the `value` should be (or not) a `Date`.
+   * @returns The return value is an instance of `TestingToBeMatchers`.
+   */
+  public date(
+    value: any,
+    expected: jasmine.Expected<boolean> = true,
+    expectationFailOutput: any = `${this.expectationFailOutput} ${
+      this.getNot() === true ? `not` : ``
+    } be a \`date\``
+  ): this {
+    this.toBe(is.date(value), expected, expectationFailOutput);
+    return this;
+  }
+
+  /**
+   * Expects provided `value` to be defined. The method uses `isDefined()` function from the `@angular-package/type`.
+   * @param value The `value` of any type that is checked against defined and the result of its check is passed to the `expect()` function
+   * of jasmine.
+   * @param expected The expected `value` of a `boolean` to compare against the result of the `value` check that is passed to the `toBe()`
+   * method of `jasmine.Matchers`.
+   * @param expectationFailOutput An additional message when the matcher fails, by default, states the `value` should be (or not) defined.
+   * @returns The return value is an instance of `TestingToBeMatchers`.
+   */
+public defined(
+  value: any,
+  expected: jasmine.Expected<boolean> = true,
+  expectationFailOutput: any = `${this.expectationFailOutput} ${
+    this.getNot() === true ? `not` : ``
+  } be defined`
+): this {
+  this.toBe(is.defined(value), expected, expectationFailOutput);
+  return this;
+}
+
+  /**
+   * Expects provided `value` to be `false`. The method uses `isFalse()` function from the `@angular-package/type`.
+   * @param value The `value` of any type that is checked against `false` and the result of its check is passed to the `expect()`
+   * function of jasmine.
+   * @param expected The expected `value` of a `boolean` to compare against the result of the `value` check that is passed to the `toBe()`
+   * method of `jasmine.Matchers`.
+   * @param expectationFailOutput An additional message when the matcher fails, by default, states the `value` should be (or not) `false`.
+   * @returns The return value is an instance of `TestingToBeMatchers`.
+   */
+  public false(
+    value: any,
+    expected: jasmine.Expected<boolean> = true,
+    expectationFailOutput: any = `${this.expectationFailOutput} ${
+      this.getNot() === true ? `not` : ``
+    } be \`false\``
+  ): this {
+    this.toBe(is.false(value), expected, expectationFailOutput);
+    return this;
+  }
+
+  /**
+   * Expects provided `value` to be `function`. The method uses `isFunction()` function from the `@angular-package/type`.
+   * @param value The `value` of any type that is checked against the `function` and the result of its check is passed to the `expect()`
+   * function of jasmine.
+   * @param expected The expected `value` of a `boolean` to compare against the result of the `value` check that is passed to the `toBe()`
+   * method of `jasmine.Matchers`.
+   * @param expectationFailOutput An additional message when the matcher fails, by default, states the `value` should be (or not)
+   * `function`.
+   * @returns The return value is an instance of `TestingToBeMatchers`.
+   */
+  public function(
+    value: any,
+    expected: jasmine.Expected<boolean> = true,
+    expectationFailOutput: any = `${this.expectationFailOutput} ${
+      this.getNot() === true ? `not` : ``
+    } be \`function\``
+  ): this {
+    this.toBe(is.function(value), expected, expectationFailOutput);
+    return this;
+  }
+
+  /**
+   * Expects provided `value` to be an instance of the given class from the `constructor`. The method uses `isInstance()` function from
+   * the `@angular-package/type`.
+   * @param value The `value` of any type that is checked against the instance of the given class and the result of its check is passed
+   * to the `expect()` function of jasmine.
+   * @param constructor A `class` or `function` that specifies the type of the `constructor`.
+   * @param expected The expected `value` of a `boolean` to compare against the result of the `value` check that is passed to the `toBe()`
+   * method of `jasmine.Matchers`.
+   * @param expectationFailOutput An additional message when the matcher fails, by default, states the `value` should be (or not) an
+   * instance of the given `class`
+   * @returns The return value is an instance of `TestingToBeMatchers`.
+   */
+  public instance<Type>(
+    value: any,
+    constructor: Constructor<Type>,
+    expected: jasmine.Expected<boolean> = true,
+    expectationFailOutput: any = `${this.expectationFailOutput} ${
+      this.getNot() === true ? `not` : ``
+    } be an instance of ${constructor.name}`
+  ): this {
+    this.toBe(is.instance(value, constructor), expected, expectationFailOutput);
+    return this;
+  }
+
+  /**
+   * Expects provided `value` to be a property key. The method uses `isKey()` function from the `@angular-package/type`.
+   * @param value The `value` of any type that is checked against the property key and the result of its check is passed to the `expect()`
+   * function of jasmine.
+   * @param expected The expected `value` of a `boolean` to compare against the result of the `value` check that is passed to the `toBe()`
+   * method of `jasmine.Matchers`.
+   * @param expectationFailOutput An additional message when the matcher fails, by default, states the `value` should be (or not) the
+   * property key.
+   * @returns The return value is an instance of `TestingToBeMatchers`.
+   */
+  public key(
+    value: any,
+    expected: jasmine.Expected<boolean> = true,
+    expectationFailOutput: any = `${this.expectationFailOutput} ${
+      this.getNot() === true ? `not` : ``
+    } be the property key`
+  ): this {
+    this.toBe(is.key(value), expected, expectationFailOutput);
+    return this;
+  }
+
+  /**
+   * Expects provided `value` to be null. The method uses `isNull()` function from the `@angular-package/type`.
+   * @param value The `value` of any type that is checked against `null` and the result of its check is passed to the `expect()` function of
+   * jasmine.
+   * @param expected The expected `value` of a `boolean` to compare against the result of the `value` check that is passed to the `toBe()`
+   * method of `jasmine.Matchers`.
+   * @param expectationFailOutput An additional message when the matcher fails, by default, states the `value` should be (or not) `null`.
+   * @returns The return value is an instance of `TestingToBeMatchers`.
+   */
+  public null(
+    value: any,
+    expected: jasmine.Expected<boolean> = true,
+    expectationFailOutput: any = `${this.expectationFailOutput} ${
+      this.getNot() === true ? `not` : ``
+    } be \`null\``
+  ): this {
+    this.toBe(is.null(value), expected, expectationFailOutput);
+    return this;
+  }
+
+  /**
+   * Expects provided `value` to be `number`. The method uses `isNumber()` function from the `@angular-package/type`.
+   * @param value The `value` of any type that is checked against the `number` and the result of its check is passed to the `expect()`
+   * function of jasmine.
+   * @param expected The expected `value` of a `boolean` to compare against the result of the `value` check that is passed to the `toBe()`
+   * method of `jasmine.Matchers`.
+   * @param expectationFailOutput An additional message when the matcher fails, by default, states the `value` should be (or not) a
+   * `number`.
+   * @returns The return value is an instance of `TestingToBeMatchers`.
+   */
+  public number(
+    value: any,
+    expected: jasmine.Expected<boolean> = true,
+    expectationFailOutput: any = `${this.expectationFailOutput} ${
+      this.getNot() === true ? `not` : ``
+    } be \`number\``
+  ): this {
+    this.toBe(is.number(value), expected, expectationFailOutput);
+    return this;
+  }
+
+  /**
+   * Expects provided `value` to be a number between a range. The method uses `isNumberBetween()` function from the `@angular-package/type`.
+   * @param value The `value` of any type that is checked against a `number` of the specified range and the result of its check is passed to
+   * the `expect()` function of jasmine.
+   * @param min A `number` of the minimum range of the given `value`.
+   * @param max A `number` of the maximum range of the given `value`.
+   * @param expected The expected `value` of a `boolean` to compare against the result of the `value` check that is passed to the `toBe()`
+   * method of `jasmine.Matchers`.
+   * @param expectationFailOutput An additional message when the matcher fails, by default, states the `value` should be (or not) a `number`
+   * between minimum to maximum.
+   * @returns The return value is an instance of `TestingToBeMatchers`.
+   */
+  public numberBetween<Min extends number, Max extends number>(
+    value: any,
+    min: Min,
+    max: Max,
+    expected: jasmine.Expected<boolean> = true,
+    expectationFailOutput: any = `${this.expectationFailOutput} ${
+      this.getNot() === true ? `not` : ``
+    } be a number between ${min} to ${max}`
+  ): this {
+    this.toBe(
+      is.numberBetween(value, min, max),
+      expected,
+      expectationFailOutput
+    );
+    return this;
+  }
+
+  /**
+   * Expects provided `value` to be an object. The method uses `isObject()` function from the `@angular-package/type`.
+   * @param value The `value` of any type that is checked against an `object` and the result of its check is passed to the `expect()`
+   * function of jasmine.
+   * @param expected The expected `value` of a `boolean` to compare against the result of the `value` check that is passed to the `toBe()`
+   * method of `jasmine.Matchers`.
+   * @param expectationFailOutput An additional message when the matcher fails, by default, states the `value` should be (or not) an
+   * `object`.
+   * @returns The return value is an instance of `TestingToBeMatchers`.
+   */
+  public object(
+    value: any,
+    expected: jasmine.Expected<boolean> = true,
+    expectationFailOutput: any = `${this.expectationFailOutput} ${
+      this.getNot() === true ? `not` : ``
+    } be an \`object\``
+  ): this {
+    this.toBe(is.object(value), expected, expectationFailOutput);
+    return this;
+  }
+
+  /**
+   * Expects provided value to be an `object` with given keys. The method uses `isObjectKey()` function from the `@angular-package/type`.
+   * @param value The `value` of any type that is checked against an `object` that contains given keys and the result of its check is
+   * passed to the `expect()` function of jasmine.
+   * @param key Property name of `Key` type or an array of property names  of `Key` type of `object` from the provided `value`.
+   * @param expected The expected `value` of a `boolean` to compare against the result of the `value` check that is passed to the `toBe()`
+   * method of `jasmine.Matchers`.
+   * @param expectationFailOutput An additional message when the matcher fails, by default, states the `value` should be (or not) an
+   * `object` with all given keys.
+   * @returns The return value is an instance of `TestingToBeMatchers`.
+   */
+  public objectKey(
+    value: any,
+    key: Key | Key[],
+    expected: jasmine.Expected<boolean> = true,
+    expectationFailOutput: any = `${this.expectationFailOutput} ${
+      this.getNot() === true ? `not` : ``
+    } be an \`object\` with all given keys`
+  ): this {
+    this.toBe(is.objectKey(value, key), expected, expectationFailOutput);
+    return this;
+  }
+
+  /**
+   * Expects provided value to be an object with given keys. The method uses `isObjectKeyIn()` function from the `@angular-package/type`.
+   * @param value The `value` of any type that is checked against an object with given keys and the result of its check is passed
+   * to the `expect()` function of jasmine.
+   * @param key Property name of a `Key` type or an array of property names of `Key` type of `object` from the provided `value`.
+   * @param expected The expected `value` of a `boolean` to compare against the result of the `value` check that is passed to the `toBe()`
+   * method of `jasmine.Matchers`.
+   * @param expectationFailOutput An additional message when the matcher fails, by default, states the `value` should be (or not) an
+   * `object` with all given keys.
+   * @returns The return value is an instance of `TestingToBeMatchers`.
+   */
+  public objectKeyIn(
+    value: any,
+    key: Key | Key[],
+    expected: jasmine.Expected<boolean> = true,
+    expectationFailOutput: any = `${this.expectationFailOutput} ${
+      this.getNot() === true ? `not` : ``
+    } be an \`object\` with all given keys`
+  ): this {
+    this.toBe(is.objectKeyIn(value, key), expected, expectationFailOutput);
+    return this;
+  }
+
+  /**
+   * Expects provided `value` to be an object with some given keys. The method uses `isObjectKeys()` function from the
+   * `@angular-package/type`.
+   * @param value The `value` of any type that is checked against an `object` that contains some given keys and the result of
+   * its check is passed to the `expect()` function of jasmine.
+   * @param keys An `array` of property names of the `Key` type of `object` from the provided `value`.
+   * @param expected The expected `value` of a `boolean` to compare against the result of the `value` check that is passed to the `toBe()`
+   * method of `jasmine.Matchers`.
+   * @param expectationFailOutput An additional message when the matcher fails, by default, states the `value` should be (or not) an
+   * `object` with some given keys.
+   * @returns The return value is an instance of `TestingToBeMatchers`.
+   */
+  public objectKeys(
+    value: any,
+    keys: Key[],
+    expected: jasmine.Expected<boolean> = true,
+    expectationFailOutput: any = `${this.expectationFailOutput} ${
+      this.getNot() === true ? `not` : ``
+    } be an \`object\` with some of the given keys`
+  ): this {
+    this.toBe(is.objectKeys(value, ...keys), expected, expectationFailOutput);
+    return this;
+  }
+
+  /**
+   * Expects provided `value` to be `RegExp`. The method uses `isRegExp()` function from the `@angular-package/type`.
+   * @param value The `value` of any type that is checked against `RegExp` and the result of its check is passed to the `expect()`
+   * function of jasmine.
+   * @param expected The expected `value` of a `boolean` to compare against the result of the `value` check that is passed to the `toBe()`
+   * method of `jasmine.Matchers`.
+   * @param expectationFailOutput An additional message when the matcher fails, by default, states the `value` should be (or not) `regexp`.
+   * @returns The return value is an instance of `TestingToBeMatchers`.
+   */
+  public regexp(
+    value: any,
+    expected: jasmine.Expected<boolean> = true,
+    expectationFailOutput: any = `${this.expectationFailOutput} ${
+      this.getNot() === true ? `not` : ``
+    } be \`regexp\``
+  ): this {
+    this.toBe(is.regexp(value), expected, expectationFailOutput);
+    return this;
+  }
+
+  /**
+   * Expects provided `value` to be a `string`. The method uses `isString()` function from the `@angular-package/type`.
+   * @param value The `value` of any type that is checked against a `string` and the result of its check is passed to the `expect()`
+   * function of jasmine.
+   * @param expected The expected `value` of a `boolean` to compare against the result of the `value` check that is passed to the `toBe()`
+   * method of `jasmine.Matchers`.
+   * @param expectationFailOutput An additional message when the matcher fails, by default, states the value should be (or not) a `string`.
+   * @returns The return value is an instance of `TestingToBeMatchers`.
+   */
+  public string(
+    value: any,
+    expected: jasmine.Expected<boolean> = true,
+    expectationFailOutput: any = `${this.expectationFailOutput} ${
+      this.getNot() === true ? `not` : ``
+    } be a \`string\``
+  ): this {
+    this.toBe(is.string(value), expected, expectationFailOutput);
+    return this;
+  }
+
+  /**
+   * Expects provided `value` to be a `string` of the length between the given minimum to maximum. The method uses `isStringLength()`
+   * function from the `@angular-package/type`.
+   * @param value The `value` of any type that is checked against a `string` of the specified length and the result of its check is passed
+   * to the `expect()` function of jasmine.
+   * @param min Minimum length of the given `value` of a `number` type.
+   * @param max The maximum length of the given `value` of a `number` type.
+   * @param expected The expected `value` of a `boolean` to compare against the result of the `value` check that is passed to the `toBe()`
+   * method of `jasmine.Matchers`.
+   * @param expectationFailOutput An additional message when the matcher fails, by default, states the value should be (or not) a `string`
+   * of the length between the given minimum to maximum.
+   * @returns The return value is an instance of `TestingToBeMatchers`.
+   */
+  public stringOfLength<Min extends number, Max extends number>(
+    value: any,
+    min: Min,
+    max: Max,
+    expected: jasmine.Expected<boolean> = true,
+    expectationFailOutput: any = `${this.expectationFailOutput} ${
+      this.getNot() === true ? `not` : ``
+    } be a \`string\` of the length between the given ${min} to ${max}`
+  ): this {
+    this.toBe(
+      is.stringLength(value, min, max),
+      expected,
+      expectationFailOutput
+    );
+    return this;
+  }
+
+  /**
+   * Expects provided `value` to be a `symbol`. The method uses `isSymbol()` function from the `@angular-package/type`.
+   * @param value The `value` of any type that is checked against the `symbol` and the result of its check is passed to the `expect()`
+   * function of jasmine.
+   * @param expected The expected `value` of a `boolean` to compare against the result of the `value` check that is passed to the `toBe()`
+   * method of `jasmine.Matchers`.
+   * @param expectationFailOutput An additional message when the matcher fails, by default, states the value should be (or not) a `symbol`.
+   * @returns The return value is an instance of `TestingToBeMatchers`.
+   */
+  public symbol(
+    value: any,
+    expected: jasmine.Expected<boolean> = true,
+    expectationFailOutput: any = `${this.expectationFailOutput} ${
+      this.getNot() === true ? `not` : ``
+    } be a \`symbol\``
+  ): this {
+    this.toBe(is.symbol(value), expected, expectationFailOutput);
+    return this;
+  }
+
+  /**
+   * Expects provided `value` to be `true`. The method uses `isTrue()` function from the `@angular-package/type`.
+   * @param value The `value` of any type that is checked against `true` and the result of its check is passed to the `expect()`
+   * function of jasmine.
+   * @param expected The expected `value` of a `boolean` to compare against the result of the `value` check that is passed to the `toBe()`
+   * method of `jasmine.Matchers`.
+   * @param expectationFailOutput An additional message when the matcher fails, by default, states the value should be (or not) `true`.
+   * @returns The return value is an instance of `TestingToBeMatchers`.
+   */
+  public true(
+    value: any,
+    expected: jasmine.Expected<boolean> = true,
+    expectationFailOutput: any = `${this.expectationFailOutput} ${
+      this.getNot() === true ? `not` : ``
+    } be \`true\``
+  ): this {
+    this.toBe(is.true(value), expected, expectationFailOutput);
+    return this;
+  }
+
+  /**
+   * Expects provided `value` to be `undefined`. The method uses `isUndefined()` function from the `@angular-package/type`.
+   * @param value The `value` of any type that is checked against `undefined` and the result of its check is passed to the `expect()`
+   * function of jasmine.
+   * @param expected The expected `value` of a `boolean` to compare against the result of the `value` check that is passed to the `toBe()`
+   * method of `jasmine.Matchers`.
+   * @param expectationFailOutput An additional message when the matcher fails, by default, states the value should be (or not) `undefined`.
+   * @returns The return value is an instance of `TestingToBeMatchers`.
+   */
+  public undefined(
+    value: any,
+    expected: jasmine.Expected<boolean> = true,
+    expectationFailOutput: any = `${this.expectationFailOutput} ${
+      this.getNot() === true ? `not` : ``
+    } be \`undefined\``
+  ): this {
+    this.toBe(is.undefined(value), expected, expectationFailOutput);
+    return this;
+  }
+
+  /**
+   * Expects provided `value` to be the given `expected`.
+   * @param value The `value` of a generic `Value` type captured from the given `value` and passed to the `expect()` function of
+   * jasmine.
+   * @param expected The expected value to compare against the given `value`, passed to the `toBe()` method of `jasmine.Matchers`.
+   * @param expectationFailOutput An additional message when the matcher fails, by default, states the value should be (or not) of a
+   * specific from the method type.
+   * @returns The return value is an instance of a `TestingMatchers`.
+   */
+  private toBe<Value>(
+    value: Value,
+    expected: jasmine.Expected<Value>,
+    expectationFailOutput?: any
+  ): this {
+    this.expect(value).toBe(expected, expectationFailOutput);
+    this.setNot(false);
+    return this;
+  }
+}

--- a/src/public-api.ts
+++ b/src/public-api.ts
@@ -2,7 +2,13 @@
  * Public API Surface of testing
  */
 // Class.
-export { Testing } from './lib';
+export { Testing, TestingToBeMatchers } from './lib';
+
+export {
+  // Example class for testing.
+  TestingClass,
+  TestingPerson,
+} from './lib/constants';
 
 // Constants.
 export {
@@ -23,8 +29,6 @@ export {
   // Class.
   TESTING_CLASS,
   TESTING_PERSON,
-  TestingClass,
-  TestingPerson,
   // Date.
   TESTING_DATE,
   // Boolean.

--- a/src/test/README.md.spec.ts
+++ b/src/test/README.md.spec.ts
@@ -1,0 +1,119 @@
+// Example usage.
+import { Testing, TestingToBeMatchers } from '../lib';
+import { TestingClass } from '../lib/constants/class.const';
+/**
+ * Create `Testing` instance.
+ */
+const testing = new Testing(true, true);
+const toBe = new TestingToBeMatchers();
+/**
+ * Tests.
+ */
+testing.describe('Expects provided value', () => {
+  let testArray: any;
+  beforeEach(() => (testArray = [1, 'two', 3]));
+
+  let isBigint: any;
+  beforeEach(() => (isBigint = 12n));
+
+  let isBoolean: any;
+  beforeEach(() => (isBoolean = false));
+
+  let isDate: any;
+  beforeEach(() => (isDate = new Date()));
+
+  testing.describe('to be or not to be the type of', () => {
+    testing.it('an `array`', () => toBe.array(testArray).not.array(2));
+    testing.it('`bigint`', () => toBe.bigint(isBigint).not.bigint(2));
+    testing.it('`boolean`', () => toBe.boolean(isBoolean).not.boolean(3));
+    testing.it('`Date`', () => toBe.date(isDate).not.date(false));
+  });
+
+  let isClass: any;
+  beforeEach(() => (isClass = class TestingClass {}));
+
+  let isFalse: any;
+  beforeEach(() => (isFalse = false));
+
+  let isDefined: any;
+
+  let isFunction: any;
+  beforeEach(() => (isFunction = () => {}));
+
+  let isKey: any;
+  beforeEach(() => (isKey = 'firstName'));
+
+  let isNull: any;
+  beforeEach(() => (isNull = null));
+
+  let isNumber: any;
+  beforeEach(() => (isNumber = 27));
+
+  let isNumberBetween: any;
+  let min: any;
+  let max: any;
+  beforeEach(() => {
+    isNumberBetween = 27;
+    min = 26;
+    max = 28;
+  });
+
+  let isObject: any;
+  beforeEach(() => isObject = {});
+
+  let isObjectKey: any;
+  beforeEach(() => isObjectKey = { firstName: '', lastName: ''});
+
+  let isObjectKeyIn: any;
+  beforeEach(() => isObjectKeyIn = { get firstName(): string { return 'x '; }, lastName: ''});
+
+  let isObjectKeys: any;
+  beforeEach(() => isObjectKeys = { get firstName(): string { return 'x '; }, lastName: ''});
+
+  let isRegExp: any;
+  beforeEach(() => isRegExp = /[]/g);
+
+  let isString: any;
+  beforeEach(() => isString = 'My new string');
+
+  let isStringOfLength: any;
+  beforeEach(() => isStringOfLength = 'My new string, My new string');
+
+  let isSymbol: any;
+  beforeEach(() => isSymbol = Symbol('firstName'));
+
+  let isTrue: any;
+  beforeEach(() => isTrue = true);
+
+  let isUndefined: any;
+  beforeEach(() => isUndefined = undefined);
+
+  let isInstance: any;
+  beforeEach(() => isInstance = new TestingClass());
+
+  testing.describe('to be or not to be', () => {
+    testing.it('`class`', () => toBe.class(isClass).not.class('TestingClass'));
+    testing.it('defined', () => toBe.defined('Defined').not.defined(isDefined));
+    testing.it('`false`', () => toBe.false(isFalse).not.false(true));
+    testing.it('`function`', () => toBe.function(isFunction).not.function(true));
+    testing.it('`key`', () => toBe.key(isKey).not.key(true));
+    testing.it('`null`', () => toBe.null(isNull).not.null(undefined));
+    testing.it('`number`', () => toBe.number(isNumber).not.number(undefined));
+    testing.it(`\`number\` between 26 to 28`, () => toBe.numberBetween(isNumber, min, max).not.number(127, min, max));
+    testing.it(`an \`object\``, () => toBe.object(isObject).not.object(undefined));
+    testing.it(`an \`object\` with all given keys`, () =>
+      toBe.objectKey(isObjectKey, ['firstName', 'lastName']).not.objectKey(isObjectKey, ['noFirstName']));
+    testing.it(`an \`object\` with all given keys`, () =>
+      toBe.objectKeyIn(isObjectKeyIn, ['firstName', 'lastName']).not.objectKeyIn(isObjectKeyIn, ['noFirstName']));
+    testing.it(`an \`object\` with some of the given keys`, () =>
+      toBe.objectKeys(isObjectKeys, ['firstName', 'lastName', 'noFirstName']).not.objectKeys(isObjectKeys, ['noFirstName']));
+    testing.it(`\`RegExp\``, () => toBe.regexp(isRegExp).not.regexp(undefined));
+    testing.it(`a \`string\``, () => toBe.string(isString).not.string(undefined));
+    testing.it(`a \`string\` between the given length`, () =>
+      toBe.stringOfLength(isStringOfLength, min, max).not.stringOfLength(undefined, min, max));
+    testing.it(`a \`symbol\``, () => toBe.symbol(isSymbol).not.symbol(undefined));
+    testing.it(`\`true\``, () => toBe.true(isTrue).not.true(false));
+    testing.it(`\`undefined\``, () => toBe.undefined(isUndefined).not.undefined(null));
+    testing.it(`an instance of \`TestingClass\``, () => toBe.instance(isInstance, TestingClass).not.instance(isInstance, class Person {}));
+  });
+});

--- a/src/test/testing-tobe-matchers.spec.ts
+++ b/src/test/testing-tobe-matchers.spec.ts
@@ -1,0 +1,76 @@
+// Class.
+import { Testing } from '../lib/testing.class';
+import { TestingToBeMatchers } from '../lib/testing-tobe-matchers.class';
+// Constants.
+import { TESTING_ARRAY_BIGINT } from '../lib/constants/array.const';
+import { TESTING_BIGINT } from '../lib/constants/big-int.const';
+import { TESTING_CLASS, TestingClass, TestingPerson } from '../lib/constants/class.const';
+import { TESTING_DATE } from '../lib/constants/date.const';
+import { TESTING_FUNCTION } from '../lib/constants/function.const';
+import { TESTING_NOT_DEFINED } from '../lib/variable/not-defined.variable';
+import { TESTING_NULL } from '../lib/constants/null.const';
+import { TESTING_NUMBER } from '../lib/constants/number.const';
+import { TESTING_OBJECT } from '../lib/constants/object.const';
+import { TESTING_REGEXP } from '../lib/constants/regexp.const';
+import { TESTING_STRING } from '../lib/constants/string.const';
+import { TESTING_SYMBOL_NUMBER } from '../lib/constants/symbol.const';
+import { TESTING_TRUE, TESTING_FALSE } from '../lib/constants/boolean.const';
+import { TESTING_UNDEFINED } from '../lib/constants/undefined.const';
+/**
+ * Create `Testing` instance.
+ */
+const testing = new Testing(false, true);
+/**
+ * Tests.
+ */
+testing.describe('Expects', () => {
+  const toBe = new TestingToBeMatchers();
+  testing
+    .it('toBe.array',          () => toBe.array(TESTING_ARRAY_BIGINT))
+    .it('toBe.bigint',         () => toBe.bigint(TESTING_BIGINT))
+    .it('toBe.boolean',        () => toBe.boolean(TESTING_TRUE))
+    .it('toBe.class',          () => toBe.class(TestingToBeMatchers))
+    .it('toBe.date',           () => toBe.date(new Date()))
+    .it('toBe.false',          () => toBe.false(TESTING_FALSE))
+    .it('toBe.function',       () => toBe.function(TESTING_FUNCTION))
+    .it('toBe.instance',       () => toBe.instance(new TestingClass(), TestingClass))
+    .it('toBe.key',            () => toBe.key(TESTING_STRING))
+    .it('toBe.null',           () => toBe.null(TESTING_NULL))
+    .it('toBe.number',         () => toBe.number(TESTING_NUMBER))
+    .it('toBe.numberBetween',  () => toBe.numberBetween(TESTING_NUMBER, 0, 10304051))
+    .it('toBe.object',         () => toBe.object(TESTING_OBJECT))
+    .it('toBe.objectKey',      () => toBe.objectKey(TESTING_OBJECT, 'key as string'))
+    .it('toBe.objectKeyIn',    () => toBe.objectKeyIn(TESTING_OBJECT, 'key as string'))
+    .it('toBe.objectKeys',     () => toBe.objectKeys(TESTING_OBJECT, ['!@#$%^&*()Company']))
+    .it('toBe.regexp',         () => toBe.regexp(TESTING_REGEXP))
+    .it('toBe.string',         () => toBe.string(TESTING_STRING))
+    .it('toBe.stringOfLength', () => toBe.stringOfLength(TESTING_STRING, 0, 200))
+    .it('toBe.symbol',         () => toBe.symbol(TESTING_SYMBOL_NUMBER))
+    .it('toBe.true',           () => toBe.true(TESTING_TRUE))
+    .it('toBe.undefined',      () => toBe.undefined(TESTING_UNDEFINED))
+    ;
+  testing
+    .it('toBe.not.array',          () => toBe.not.array(TESTING_BIGINT))
+    .it('toBe.not.bigint',         () => toBe.not.bigint(TESTING_ARRAY_BIGINT))
+    .it('toBe.not.boolean',        () => toBe.not.boolean(TESTING_NOT_DEFINED))
+    .it('toBe.not.class',          () => toBe.not.class(TESTING_CLASS))
+    .it('toBe.not.date',           () => toBe.not.date(TESTING_FUNCTION))
+    .it('toBe.not.false',          () => toBe.not.false(TESTING_NULL))
+    .it('toBe.not.function',       () => toBe.not.function(TESTING_OBJECT))
+    .it('toBe.not.instance',       () => toBe.not.instance(new TestingPerson(), TestingClass))
+    .it('toBe.not.key',            () => toBe.not.key(TESTING_BIGINT))
+    .it('toBe.not.null',           () => toBe.not.null(TESTING_CLASS))
+    .it('toBe.not.number',         () => toBe.not.number(TESTING_STRING))
+    .it('toBe.not.numberBetween',  () => toBe.not.numberBetween(TESTING_NUMBER, 0, 10304049))
+    .it('toBe.not.object',         () => toBe.not.object(null))
+    .it('toBe.not.objectKey',      () => toBe.not.objectKey({} as object, 'key as string'))
+    .it('toBe.not.objectKeyIn',    () => toBe.not.objectKeyIn({} as object, 'key as string'))
+    .it('toBe.not.objectKeys',     () => toBe.not.objectKeys({} as object, ['!@#$%^&*()Company']))
+    .it('toBe.not.regexp',         () => toBe.not.regexp(TESTING_UNDEFINED))
+    .it('toBe.not.string',         () => toBe.not.string(TESTING_NUMBER))
+    .it('toBe.not.stringOfLength', () => toBe.not.stringOfLength(TESTING_STRING, 0, 1))
+    .it('toBe.not.symbol',         () => toBe.not.symbol(TESTING_DATE))
+    .it('toBe.not.true',           () => toBe.not.true(TESTING_NUMBER))
+    .it('toBe.not.undefined',      () => toBe.not.undefined(TESTING_REGEXP))
+    ;
+});


### PR DESCRIPTION
## [1.1.0] - 2021-07-19

### Added

- 77f326a
  Abstract `TestingExpect` class to manage `expect()` function of jasmine.

- afb98f5
  Class `TestingToBeMatchers` with matchers that use the `toBe()` method of `jasmine.Matchers`.

- 3bf2046
  Tests for the `TestingToBeMatchers`.

### Changed

- 4b81d0c bdfbfe2 8229336 c17d11e 9e0e368
  Update README.md with `TestingToBeMatchers`.
